### PR TITLE
Updated the documentation to use composite and partial documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 *.iml
 **/test.properties
+
+# Visual Studio Code
+.vscode

--- a/ginisdk/src/doc/source/changelog.rst
+++ b/ginisdk/src/doc/source/changelog.rst
@@ -22,9 +22,9 @@ Changelog
 2.0.0-beta.1 (2018-04-04)
 =========================
 
-- Support for composite (multi-page) document analysis. A composite document consists of one or more partial documents.
-For each page you need to create a partial document. Using these you can create a composite document for which you can
-get the extractions after polling has finished.
+- Support for composite (multi-page) document analysis. A composite document consists of one or more
+  partial documents. For each page you need to create a partial document. Using these you can create a
+  composite document for which you can get the extractions after polling has finished.
 
 1.5.0 (2018-02-08)
 ===================

--- a/ginisdk/src/doc/source/guides/common-tasks.rst
+++ b/ginisdk/src/doc/source/guides/common-tasks.rst
@@ -64,16 +64,6 @@ upload. For retrieving extractions see :ref:`getting-extractions`.
     The filename (``myFirstDocument.jpg`` in the example) is not required, it could be ``null``, but
     setting a filename is a good praxis for human readable document identification.
 
-Working with optional arguments
--------------------------------
-
-You may have noticed that we used ``null`` as the argument for the document's doctype in the
-example. This is completely valid since the argument is annoted with the ``Nullable`` annotation
-(``@org.jetbrains.annotations.Nullable``). All methods that accept null arguments use the
-``@Nullable`` annotation for those arguments. Consider all arguments which do not have the
-``@Nullable`` annotation as mandatory. The method will raise a ``NullPointerException`` if you pass
-``null`` to such arguments.
-
 Setting the document type hint
 ------------------------------
 

--- a/ginisdk/src/doc/source/guides/common-tasks.rst
+++ b/ginisdk/src/doc/source/guides/common-tasks.rst
@@ -182,10 +182,11 @@ feedback.
 Report an extraction error to Gini
 ==================================
 
-If the processing result for a document was not satisfactory for the user, your app can give her the
-opportunity to report a error directly to Gini. Gini will return a error identifier which can be
-used to refer to it towards the Gini support. The user must agree that Gini can use this document
-for debugging and error analysis. The code example below shows how to send the error report to Gini.
+If the processing result for a document was not satisfactory for the user, your app can enable your
+user the opportunity to report an error directly to Gini. Gini will return an error identifier which
+can be used to refer to it towards the Gini support. The user must agree that Gini can use this
+document for debugging and error analysis. The code example below shows how to send the error report
+to Gini.
 
 .. code-block:: java
 

--- a/ginisdk/src/doc/source/guides/common-tasks.rst
+++ b/ginisdk/src/doc/source/guides/common-tasks.rst
@@ -5,54 +5,24 @@ Working with Tasks
 ==================
 
 The Gini Android SDK makes heavy use of the concept of tasks. Tasks are convenient when you want to
-do a series of tasks in a row, each one waiting waiting for the previous to finish (comparable to
-Promises in JavaScript). This is a common pattern when working with Gini's remote API.
-The Gini Android SDK uses `facebook's task implementation, which is called bolts <https://github.com/BoltsFramework/Bolts-Android>`_.
-Before you continue reading this guide, we strongly encourage you to read the `short guide for the Bolts
-framework <https://github.com/BoltsFramework/Bolts-Android/blob/master/Readme.md#tasks>`_.
+do execute work in succession, each one waiting for the previous to finish (comparable to
+Promises in JavaScript). This is a common pattern when working with Gini's remote API. The Gini
+Android SDK uses `facebook's task implementation, which is called bolts
+<https://github.com/BoltsFramework/Bolts-Android>`_. Before you continue reading this guide, we
+strongly encourage you to read the `short guide for the Bolts framework
+<https://github.com/BoltsFramework/Bolts-Android/blob/master/Readme.md#tasks>`_.
 
 Upload a document
 =================
 
 As the key aspect of the Gini API is to provide information extraction for analyzing documents, the
-API is mainly built around the concept of documents. A document can be any written representation
-of information, usually such as invoices, reminders, contracts and so on.
+API is mainly built around the concept of documents. A document can be any written representation of
+information such as invoices, reminders, contracts and so on.
 
-The Gini Android SDK supports creating documents from images, PDFs or UTF-8 encoded text. Images are usually a picture of a paper document
-which was taken with the device's camera.
+The Gini Android SDK supports creating documents from images, PDFs or UTF-8 encoded text. Images are
+usually a picture of a paper document which was taken with the device's camera.
 
-The following example shows how to create a new document from a bitmap.
-
-.. code-block:: java
-
-    import net.gini.android.Gini;
-    import net.gini.android.DocumentTaskManager;
-    import net.gini.android.models.Document;
-    
-    ...
-    
-    // Assuming that `gini` is an instance of the `Gini` facade class and `bitmap` is an instance of Android's
-    // Bitmap class, e.g. from a picture taken by the camera.
-    
-    DocumentTaskManager documentTaskManager = gini.getDocumentTaskManager();
-    documentTaskManager.createDocument(bitmap, "myFirstDocument.jpg", null).onSuccess(new Continuation<Document, Void>() {
-                @Override
-                public Void then(Task<Document> task) throws Exception {
-                    Document document = task.getResult();
-                    Log.d("gini", "Created document with ID " + document.getId());
-                    return null;
-                }
-    });
-
-.. note::
-    
-    ``createDocument(document, filename, documentType, compressionRate)`` was deprecated and should be replaced with
-    ``createDocument(document, filename, documentType)``. We use a compression rate optimized to get the best extractions
-    for the smallest image byte size. Also note that document type is now a `DocumentType` enum instead of a `String`. See 
-    `Setting the document type hint`_ for details.
-
-
-To create a document from a jpeg, PDF or text these have to be uploaded as a byte array as seen in the following example.
+The following example shows how to create a new document from a byte array containing a JPEG image.
 
 .. code-block:: java
 
@@ -62,54 +32,81 @@ To create a document from a jpeg, PDF or text these have to be uploaded as a byt
     
     ...
     
-    // Assuming that `gini` is an instance of the `Gini` facade class and `bytes` is a byte array containing a PDF or UTF-8
-    // encoded text
-
+    // Assuming that `gini` is an instance of the `Gini` facade class and `imageBytes`
+    // is an instance of a byte array containing a JPEG image, 
+    // e.g. from a picture taken by the camera
+    
     DocumentTaskManager documentTaskManager = gini.getDocumentTaskManager();
-    documentTaskManager.createDocument(bytes, "myFirstDocument.pdf", DocumentType.INVOICE).onSuccess(new Continuation<Document, Void>() {
-                @Override
-                public Void then(Task<Document> task) throws Exception {
-                    Document document = task.getResult();
-                    Log.d("gini", "Created document with ID " + document.getId());
-                    return null;
-                }
-    });
+    documentTaskManager.createPartialDocument(imageBytes, "image/jpeg", "myFirstDocument.jpg", null)
+        .onSuccess(new Continuation<Document, Void>() {
+            @Override
+            public Void then(Task<Document> task) throws Exception {
+                Document document = task.getResult();
+                return null;
+            }
+        });
+
+In version 2.0.0 we introduced *partial documents* to allow scanning documents with multiple pages.
+Each page of a document needs to uploaded as a partial document. In addition documents consisting of
+one page also should be uploaded as a partial document.
+
+.. note::
+
+    PDFs and UTF-8 encoded text should also be uploaded as partial documents. Even though PDFs might
+    contain multiple pages and text is "pageless", creating partial documents for these keeps your
+    interaction with Gini consistent for all the supported document types.
+
+Extractions are not available for partial documents. Creating a partial document is analogous to an
+upload. For retrieving extractions see :ref:`getting-extractions`.
 
 .. note::
     
-    The filename (``myFirstDocument.pdf`` in the example) is not required, it could be ``null``, but setting a filename is a good praxis
-    for human readable document identification.
-
+    The filename (``myFirstDocument.jpg`` in the example) is not required, it could be ``null``, but
+    setting a filename is a good praxis for human readable document identification.
 
 Working with optional arguments
 -------------------------------
 
-You may have noticed that we used ``null`` as the argument for the document's doctype in the first example. 
-This is a completely valid thing to do since the argument is annoted with the ``Nullable``
-annotation (``@org.jetbrains.annotations.Nullable``). All methods that accept null arguments use the
-``@Nullable`` annotation for those arguments. Consider all arguments which do not have the ``@Nullable``
-annotation as mandatory. The method will raise a ``NullPointerException`` if you pass null to such
-arguments.
+You may have noticed that we used ``null`` as the argument for the document's doctype in the
+example. This is completely valid since the argument is annoted with the ``Nullable`` annotation
+(``@org.jetbrains.annotations.Nullable``). All methods that accept null arguments use the
+``@Nullable`` annotation for those arguments. Consider all arguments which do not have the
+``@Nullable`` annotation as mandatory. The method will raise a ``NullPointerException`` if you pass
+``null`` to such arguments.
 
 Setting the document type hint
 ------------------------------
 
-To easily set the document type hint we introduced the ``DocumentType`` enum. It is safer and easier to
-use than a ``String``. For more details about the document type hints see the 
-`Document Type Hints in the Gini API documentation <http://developer.gini.net/gini-api/html/documents.html#document-type-hints>`_.
+To easily set the document type hint we introduced the ``DocumentType`` enum. It is safer and easier
+to use than a ``String``. For more details about the document type hints see the `Document Type
+Hints in the Gini API documentation
+<http://developer.gini.net/gini-api/html/documents.html#document-type-hints>`_.
+
+.. _getting-extractions:
 
 Getting extractions
 ===================
 
-After you have successfully created a new document, you most likely want to get the extractions for
-the document. Gini needs to process your document first before you can fetch the document's
-extractions. Effectively this means that you won't get any extractions before the document is fully
-processed. The processing time may vary, usually it is in the range of a couple of seconds, but
-blurred or slightly rotated images are known to drasticly increase the processing time. 
+After you have successfully created the partial documents, you most likely want to get the
+extractions for the document. In version 2.0.0 we introduced *composite documents* which consist of
+previously created *partial documents*. You can consider creating partial documents analogous to
+uploading pages of a document and creating a composite document analogous to processing those page
+as a single document.
 
-The DocumentTaskManager provides the ``pollDocument`` and ``getExtractions`` methods which can be used
-to fetch the extractions after the processing of the document is completed. The following example shows 
-how to achieve this in detail.
+Before retrieving extractions you need to create a composite document from your partial documents.
+The ``createCompositeDocument()`` method accepts either a ``List`` of partial ``Documents`` or a
+``LinkedHashMap``. The ``LinkedHashMap`` contains partial ``Documents`` as keys and the user applied
+rotation as values. In both cases the order is important and the partial documents should be in the
+same order as the pages of the scanned document.
+
+Gini needs to process the composite document first before you can fetch the extractions. Effectively
+this means that you won't get any extractions before the composite document is fully processed. The
+processing time may vary, usually it is in the range of a couple of seconds, but blurred or slightly
+rotated images are known to drasticly increase the processing time. 
+
+The ``DocumentTaskManager`` provides the ``pollDocument`` and ``getExtractions`` methods which can be
+used to fetch the extractions after the processing of the document is completed. The following
+example shows how to achieve this in detail.
 
 .. code-block:: java
 
@@ -118,37 +115,48 @@ how to achieve this in detail.
         import net.gini.android.models.Document;
         import net.gini.android.models.SpecificExtraction;
         
-        
         ...
         
-        
-        // Assuming that `gini` is an instance of the `Gini` facade class and `document` is an instance
-        // of the `Document` class as returned by `createDocument(...)`.
+        // Assuming that `gini` is an instance of the `Gini` facade class and `partialDocuments` is
+        // a list of `Documents` which were returned by `createPartialDocument(...)` calls
+
         final DocumentTaskManager documentTaskManager = gini.getDocumentTaskManager();
-        documentTaskManager.pollDocument(document).
-        onSuccessTask(new Continuation<Document, Task<Map<String, SpecificExtraction>>>() {
-            @Override
-            public Object then(Task<Document> task) throws Exception {
-                final Document document = task.getResult();
-                return documentTaskManager.getExtractions(document);
-            }
-        }).
-        onSuccess(new Continuation<Map<String, SpecificExtraction>, Void>() {
-            @Override
-            public Void then(Task<Map<String, SpecificExtraction>> task) {
-                final Map<String, SpecificExtraction> extractions = task.getResult();
-                // Do something with the extractions.
-                return null;
-            }
-        });
+        documentTaskManager.createCompositeDocument(partialDocuments, null)
+            .onSuccessTask(
+                new Continuation<Document, Task<Document>>() {
+                    @Override
+                    public Task<Document> then(
+                            final Task<Document> task)
+                            throws Exception {
+                        final Document document = task.getResult();
+                        return documentTaskManager.pollDocument(document);
+                    }
+            })
+            .onSuccessTask(new Continuation<Document, Task<Map<String, SpecificExtraction>>>() {
+                @Override
+                public Object then(Task<Document> task) throws Exception {
+                    final Document document = task.getResult();
+                    return documentTaskManager.getExtractions(document);
+                }
+            })
+            .onSuccess(new Continuation<Map<String, SpecificExtraction>, Void>() {
+                @Override
+                public Void then(Task<Map<String, SpecificExtraction>> task) {
+                    final Map<String, SpecificExtraction> extractions = task.getResult();
+                    // You may use the extractions to fulfill your use-case
+                    return null;
+                }
+            });
 
 Sending feedback
 ================
 
-Depending on your use case your app probably presents the extractions to the user and give her the opportunity to correct them. Yes, there *could be errors*.
-We do our best to prevent them - but It's more unlikely to happen if your app is sending us feedback for the extractions we have delivered. Your app should send feedback
-only for the extractions the *user has seen and accepted*. Feedback should be send for corrected extractions **and** for *correct extractions*.
-The code example below shows how to correct extractions and send feedback.
+Depending on your use case your app probably presents the extractions to the user and offers the
+opportunity to correct them. We do our best to prevent errors. You can help improve our service if
+your app sends feedback for the extractions Gini delivered. Your app should send feedback only for
+the extractions the *user has seen and accepted*. Feedback should be sent for corrected extractions
+**and** for *correct extractions*. The code example below shows how to correct extractions and send
+feedback.
 
 .. code-block:: java
 
@@ -174,9 +182,10 @@ The code example below shows how to correct extractions and send feedback.
 Report an extraction error to Gini
 ==================================
 
-If the processing result for a document was not satisfactory for the user, your app can give her the opportunity to report a error directly to Gini. Gini will return
-a error identifier which can be used to refer to it towards the Gini support. The user must agree that Gini can use this document for debugging and error analysis.
-The code example below shows how to send the error report to Gini.
+If the processing result for a document was not satisfactory for the user, your app can give her the
+opportunity to report a error directly to Gini. Gini will return a error identifier which can be
+used to refer to it towards the Gini support. The user must agree that Gini can use this document
+for debugging and error analysis. The code example below shows how to send the error report to Gini.
 
 .. code-block:: java
 

--- a/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
@@ -304,7 +304,7 @@ public class DocumentTaskManager {
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
      */
-    public Task<Document> createDocument(final byte[] document, @Nullable final String filename,
+    public Task<Document> createDocument(@NonNull final byte[] document, @Nullable final String filename,
             @Nullable final DocumentType documentType) {
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override
@@ -344,7 +344,7 @@ public class DocumentTaskManager {
      * and to send feedback.
      */
     @Deprecated
-    public Task<Document> createDocument(final Bitmap document, @Nullable final String filename,
+    public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
                                          @Nullable final String documentType, final int compressionRate) {
         return createDocumentInternal(document, filename, documentType, compressionRate);
     }
@@ -364,7 +364,7 @@ public class DocumentTaskManager {
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
      */
-    public Task<Document> createDocument(final Bitmap document, @Nullable final String filename,
+    public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
                                           @Nullable final DocumentType documentType) {
         String apiDoctypeHint = null;
         if (documentType != null) {
@@ -373,7 +373,7 @@ public class DocumentTaskManager {
         return createDocumentInternal(document, filename, apiDoctypeHint, DEFAULT_COMPRESSION);
     }
 
-    private Task<Document> createDocumentInternal(final Bitmap document, @Nullable final String filename,
+    private Task<Document> createDocumentInternal(@NonNull final Bitmap document, @Nullable final String filename,
                                          @Nullable final String apiDoctypeHint, final int compressionRate) {
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override
@@ -403,7 +403,7 @@ public class DocumentTaskManager {
      * <a href="http://developer.gini.net/gini-api/html/document_extractions.html">Gini API documentation</a>
      * for a list of the names of the specific extractions.
      */
-    public Task<Map<String, SpecificExtraction>> getExtractions(final Document document) {
+    public Task<Map<String, SpecificExtraction>> getExtractions(@NonNull final Document document) {
         final String documentId = document.getId();
         return mSessionManager.getSession()
                 .onSuccessTask(new Continuation<Session, Task<JSONObject>>() {
@@ -457,7 +457,7 @@ public class DocumentTaskManager {
      *
      * @return A document instance representing all the document's metadata.
      */
-    public Task<Document> getDocument(final String documentId) {
+    public Task<Document> getDocument(@NonNull final String documentId) {
         checkNotNull(documentId);
         return mSessionManager.getSession()
                 .onSuccessTask(new Continuation<Session, Task<JSONObject>>() {
@@ -481,7 +481,7 @@ public class DocumentTaskManager {
      *
      * @return A document instance representing all the document's metadata.
      */
-    public Task<Document> getDocument(final Uri documentUri) {
+    public Task<Document> getDocument(@NonNull final Uri documentUri) {
         checkNotNull(documentUri);
         return mSessionManager.getSession()
                 .onSuccessTask(new Continuation<Session, Task<JSONObject>>() {
@@ -504,7 +504,7 @@ public class DocumentTaskManager {
      *
      * @param document The document which will be polled.
      */
-    public Task<Document> pollDocument(final Document document) {
+    public Task<Document> pollDocument(@NonNull final Document document) {
         if (document.getState() != Document.ProcessingState.PENDING) {
             return Task.forResult(document);
         }
@@ -539,7 +539,7 @@ public class DocumentTaskManager {
      *
      * @param document The document which is being polled
      */
-    public void cancelDocumentPolling(final Document document) {
+    public void cancelDocumentPolling(@NonNull final Document document) {
         if (mDocumentPollingsInProgress.containsKey(document)) {
             mDocumentPollingsInProgress.put(document, true);
         }
@@ -560,8 +560,8 @@ public class DocumentTaskManager {
      *
      * @throws JSONException When a value of an extraction is not JSON serializable.
      */
-    public Task<Document> sendFeedbackForExtractions(final Document document,
-                                                     final Map<String, SpecificExtraction> extractions)
+    public Task<Document> sendFeedbackForExtractions(@NonNull final Document document,
+            @NonNull final Map<String, SpecificExtraction> extractions)
             throws JSONException {
         final String documentId = document.getId();
         final JSONObject feedbackForExtractions = new JSONObject();
@@ -604,8 +604,8 @@ public class DocumentTaskManager {
      * @return A Task which will resolve to an error ID. This is a unique identifier for your error report
      * and can be used to refer to the reported error towards the Gini support.
      */
-    public Task<String> reportDocument(final Document document, final @Nullable String summary,
-                                       final @Nullable String description) {
+    public Task<String> reportDocument(@NonNull final Document document, @Nullable final String summary,
+            @Nullable final String description) {
         final String documentId = document.getId();
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<JSONObject>>() {
             @Override
@@ -630,7 +630,7 @@ public class DocumentTaskManager {
      *
      * @return A task which will resolve to a string containing the layout xml.
      */
-    public Task<JSONObject> getLayout(final Document document) {
+    public Task<JSONObject> getLayout(@NonNull final Document document) {
         final String documentId = document.getId();
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<JSONObject>>() {
             @Override
@@ -651,7 +651,7 @@ public class DocumentTaskManager {
      *
      * @throws JSONException If the JSON data does not have the expected structure or if there is invalid data.
      */
-    protected HashMap<String, List<Extraction>> extractionCandidatesFromApiResponse(final JSONObject responseData)
+    protected HashMap<String, List<Extraction>> extractionCandidatesFromApiResponse(@NonNull final JSONObject responseData)
             throws JSONException {
         final HashMap<String, List<Extraction>> candidatesByEntity = new HashMap<String, List<Extraction>>();
 
@@ -679,7 +679,7 @@ public class DocumentTaskManager {
      *
      * @throws JSONException If the JSON data does not have the expected structure or if there is invalid data.
      */
-    protected Extraction extractionFromApiResponse(final JSONObject responseData) throws JSONException {
+    protected Extraction extractionFromApiResponse(@NonNull final JSONObject responseData) throws JSONException {
         final String entity = responseData.getString("entity");
         final String value = responseData.getString("value");
         // The box is optional for some extractions.
@@ -713,7 +713,7 @@ public class DocumentTaskManager {
          * @param documentBitmap A Bitmap representing the image.
          */
         @Deprecated
-        public DocumentUploadBuilder(final Bitmap documentBitmap) {
+        public DocumentUploadBuilder(@NonNull final Bitmap documentBitmap) {
             mDocumentBitmap = documentBitmap;
             mCompressionRate = DocumentTaskManager.DEFAULT_COMPRESSION;
         }
@@ -721,7 +721,7 @@ public class DocumentTaskManager {
         /**
          * Set the document as a byte array. If a {@link Bitmap} was also set, the bitmap will be used.
          */
-        public DocumentUploadBuilder setDocumentBytes(byte[] documentBytes) {
+        public DocumentUploadBuilder setDocumentBytes(@NonNull byte[] documentBytes) {
             this.mDocumentBytes = documentBytes;
             return this;
         }
@@ -729,7 +729,7 @@ public class DocumentTaskManager {
         /**
          * Set the document as a {@link Bitmap}. This bitmap will be used instead of the byte array, if both were set.
          */
-        public DocumentUploadBuilder setDocumentBitmap(Bitmap documentBitmap) {
+        public DocumentUploadBuilder setDocumentBitmap(@NonNull Bitmap documentBitmap) {
             this.mDocumentBitmap = documentBitmap;
             return this;
         }
@@ -737,7 +737,7 @@ public class DocumentTaskManager {
         /**
          * Set the document' s filename.
          */
-        public DocumentUploadBuilder setFilename(final String filename) {
+        public DocumentUploadBuilder setFilename(@NonNull final String filename) {
             mFilename = filename;
             return this;
         }
@@ -749,7 +749,7 @@ public class DocumentTaskManager {
          * @deprecated Use {@link #setDocumentType(DocumentType)} instead.
          */
         @Deprecated
-        public DocumentUploadBuilder setDocumentType(final String documentType) {
+        public DocumentUploadBuilder setDocumentType(@NonNull final String documentType) {
             mDocumentType = documentType;
             return this;
         }
@@ -758,7 +758,7 @@ public class DocumentTaskManager {
          * Set the document's type. (This feature is called document type hint in the Gini API documentation). By
          * providing the doctype, Gini’s document processing is optimized in many ways.
          */
-        public DocumentUploadBuilder setDocumentType(final DocumentType documentType) {
+        public DocumentUploadBuilder setDocumentType(@NonNull final DocumentType documentType) {
             mDocumentTypeHint = documentType;
             return this;
         }
@@ -783,7 +783,7 @@ public class DocumentTaskManager {
          *
          * @return A task which will resolve to a Document instance.
          */
-        public Task<Document> upload(final DocumentTaskManager documentTaskManager) {
+        public Task<Document> upload(@NonNull final DocumentTaskManager documentTaskManager) {
             if (mDocumentBitmap != null) {
                 if (mDocumentTypeHint != null) {
                     return documentTaskManager.createDocument(mDocumentBitmap, mFilename, mDocumentTypeHint);

--- a/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
@@ -4,6 +4,7 @@ import static net.gini.android.Utils.checkNotNull;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
 import android.support.annotation.XmlRes;
 
 import com.android.volley.Cache;
@@ -59,8 +60,8 @@ public class SdkBuilder {
      * @param clientSecret Your application's client secret for the Gini API.
      * @param emailDomain  The email domain which is used for created Gini users.
      */
-    public SdkBuilder(final Context context, final String clientId, final String clientSecret,
-            final String emailDomain) {
+    public SdkBuilder(@NonNull final Context context, @NonNull final String clientId,
+            @NonNull final String clientSecret, @NonNull final String emailDomain) {
         mContext = context;
         mEmailDomain = emailDomain;
         mClientSecret = clientSecret;
@@ -74,7 +75,7 @@ public class SdkBuilder {
      * @param context        Your application's Context instance (Android).
      * @param sessionManager The SessionManager to use.
      */
-    public SdkBuilder(final Context context, final SessionManager sessionManager) {
+    public SdkBuilder(@NonNull final Context context, @NonNull final SessionManager sessionManager) {
         mContext = context;
         mSessionManager = sessionManager;
     }
@@ -96,7 +97,7 @@ public class SdkBuilder {
      * @param newUrl The URL of the Gini API which is used by the requests of the Gini SDK.
      * @return The builder instance to enable chaining.
      */
-    public SdkBuilder setApiBaseUrl(String newUrl) {
+    public SdkBuilder setApiBaseUrl(@NonNull String newUrl) {
         if (!newUrl.endsWith("/")) {
             newUrl += "/";
         }
@@ -110,7 +111,7 @@ public class SdkBuilder {
      * @param newUrl The URL of the Gini User Center API which is used by the requests of the Gini SDK.
      * @return The builder instance to enable chaining.
      */
-    public SdkBuilder setUserCenterApiBaseUrl(String newUrl) {
+    public SdkBuilder setUserCenterApiBaseUrl(@NonNull String newUrl) {
         if (!newUrl.endsWith("/")) {
             newUrl += "/";
         }
@@ -169,7 +170,7 @@ public class SdkBuilder {
      * @param credentialsStore A credentials store instance (specified by the CredentialsStore interface).
      * @return The builder instance to enable chaining.
      */
-    public SdkBuilder setCredentialsStore(CredentialsStore credentialsStore) {
+    public SdkBuilder setCredentialsStore(@NonNull CredentialsStore credentialsStore) {
         mCredentialsStore = checkNotNull(credentialsStore);
         return this;
     }
@@ -181,7 +182,7 @@ public class SdkBuilder {
      * @param cache A cache instance (specified by the com.android.volley.Cache interface).
      * @return The builder instance to enable chaining.
      */
-    public SdkBuilder setCache(Cache cache) {
+    public SdkBuilder setCache(@NonNull Cache cache) {
         mCache = cache;
         return this;
     }
@@ -201,6 +202,7 @@ public class SdkBuilder {
      *
      * @return The RequestQueue instance.
      */
+    @NonNull
     private synchronized RequestQueue getRequestQueue() {
         if (mRequestQueue == null) {
             RequestQueueBuilder requestQueueBuilder = new RequestQueueBuilder(mContext);
@@ -216,6 +218,7 @@ public class SdkBuilder {
         return mRequestQueue;
     }
 
+    @NonNull
     private List<String> getHostnames() {
         final List<String> hostnames = new ArrayList<>(2);
         try {
@@ -236,6 +239,7 @@ public class SdkBuilder {
      *
      * @return The ApiCommunicator instance.
      */
+    @NonNull
     private synchronized ApiCommunicator getApiCommunicator() {
         if (mApiCommunicator == null) {
             mApiCommunicator = new ApiCommunicator(mApiBaseUrl, getRequestQueue(),
@@ -252,6 +256,7 @@ public class SdkBuilder {
      *
      * @return The CredentialsStore instance.
      */
+    @NonNull
     private synchronized CredentialsStore getCredentialsStore() {
         if (mCredentialsStore == null) {
             SharedPreferences sharedPreferences = mContext.getSharedPreferences("Gini",
@@ -267,6 +272,7 @@ public class SdkBuilder {
      *
      * @return The ApiCommunicator instance.
      */
+    @NonNull
     private synchronized UserCenterAPICommunicator getUserCenterAPICommunicator() {
         if (mUserCenterApiCommunicator == null) {
             mUserCenterApiCommunicator =
@@ -283,6 +289,7 @@ public class SdkBuilder {
      *
      * @return The RetryPolicyFactory instance.
      */
+    @NonNull
     private synchronized RetryPolicyFactory getRetryPolicyFactory() {
         if (mRetryPolicyFactory == null) {
             mRetryPolicyFactory = new DefaultRetryPolicyFactory(mTimeoutInMs, mMaxRetries,
@@ -296,6 +303,7 @@ public class SdkBuilder {
      *
      * @return The UserCenterManager instance.
      */
+    @NonNull
     private synchronized UserCenterManager getUserCenterManager() {
         if (mUserCenterManager == null) {
             mUserCenterManager = new UserCenterManager(getUserCenterAPICommunicator());
@@ -308,6 +316,7 @@ public class SdkBuilder {
      *
      * @return The DocumentTaskManager instance.
      */
+    @NonNull
     private synchronized DocumentTaskManager getDocumentTaskManager() {
         if (mDocumentTaskManager == null) {
             mDocumentTaskManager = new DocumentTaskManager(getApiCommunicator(),
@@ -322,6 +331,7 @@ public class SdkBuilder {
      *
      * @return The SessionManager instance.
      */
+    @NonNull
     public synchronized SessionManager getSessionManager() {
         if (mSessionManager == null) {
             mSessionManager = new AnonymousSessionManager(mEmailDomain, getUserCenterManager(),


### PR DESCRIPTION
Documentation details now how to work with partial and composite documents. I replaced the previous descriptions and examples. We want new users to use the new API. Existing users will be able to use the previous API (now deprecated) for which Javadoc is still available.