### PR TITLE
Anonymous credentials are encrypted by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 script {
                     avd.deleteCorrupt()
-                    avd.create("api-16-nexus-5x", "system-images;android-16;google_apis;x86", "Nexus 5X")
+                    avd.create("api-19-nexus-5x", "system-images;android-19;google_apis;x86", "Nexus 5X")
                     avd.create("api-22-nexus-5x", "system-images;android-22;google_apis;x86", "Nexus 5X")
                     avd.create("api-26-nexus-5x", "system-images;android-26;google_apis;x86", "Nexus 5X")
                 }
@@ -73,10 +73,10 @@ pipeline {
                 }
             }
         }
-        stage('Instrumentation Tests - API Level 16') {
+        stage('Instrumentation Tests - API Level 19') {
             steps {
                 script {
-                    def emulatorPort = emulator.start(avd.createName("api-16-nexus-5x"), "nexus_5x", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu on -camera-back emulated -no-snapshot-save -no-snapshot-load")
+                    def emulatorPort = emulator.start(avd.createName("api-19-nexus-5x"), "nexus_5x", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu on -camera-back emulated -no-snapshot-save -no-snapshot-load")
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {

--- a/ginisdk/build.gradle
+++ b/ginisdk/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 18
         targetSdkVersion 27
         versionCode 1
         versionName version

--- a/ginisdk/build.gradle
+++ b/ginisdk/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName version

--- a/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
@@ -32,7 +32,7 @@ import java.util.Date;
 import java.util.Map;
 
 @MediumTest
-public class ApiCommunicatorTests extends InstrumentationTestCase {
+public class ApiCommunicatorTest extends InstrumentationTestCase {
     private ApiCommunicator mApiCommunicator;
     private RequestQueue mRequestQueue;
     private RetryPolicyFactory retryPolicyFactory;

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import bolts.Task;
 
 @MediumTest
-public class DocumentTaskManagerTests extends InstrumentationTestCase {
+public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
     private DocumentTaskManager mDocumentTaskManager;
     private SessionManager mSessionManager;

--- a/ginisdk/src/androidTest/java/net/gini/android/RequestTaskCompletionSourceTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/RequestTaskCompletionSourceTest.java
@@ -8,7 +8,7 @@ import com.android.volley.VolleyError;
 import bolts.Task;
 
 @SmallTest
-public class RequestTaskCompletionSourceTests extends AndroidTestCase {
+public class RequestTaskCompletionSourceTest extends AndroidTestCase {
 
     public void testNewRequestTaskCompletionSource() {
         assertNotNull(RequestTaskCompletionSource.newCompletionSource());

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
@@ -468,11 +468,12 @@ public class SdkIntegrationTest extends AndroidTestCase {
         assertEquals("IBAN should be found", "DE96490501010082009697", extractions.get("iban").getValue());
         final String amountToPay = extractions.get("amountToPay").getValue();
         assertTrue("Amount to pay should be found: "
-                        + "expected one of <[145.00:EUR, 77.00:EUR, 588.60:EUR]> but was:<["
+                        + "expected one of <[145.00:EUR, 77.00:EUR, 588.60:EUR, 700.43:EUR]> but was:<["
                         + amountToPay +"]>",
                 amountToPay.equals("145.00:EUR")
                         || amountToPay.equals("77.00:EUR")
-                        || amountToPay.equals("588.60:EUR"));
+                        || amountToPay.equals("588.60:EUR")
+                        || amountToPay.equals("700.43:EUR"));
         assertEquals("BIC should be found", "WELADED1MIN", extractions.get("bic").getValue());
         assertEquals("Payee should be found", "Mindener Stadtwerke GmbH", extractions.get("paymentRecipient").getValue());
         assertEquals("Payment reference should be found", "ReNr TST-00019, KdNr 765432", extractions.get("paymentReference").getValue());

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
@@ -15,7 +15,7 @@ import android.util.Log;
 import com.android.volley.toolbox.NoCache;
 
 import net.gini.android.DocumentTaskManager.DocumentUploadBuilder;
-import net.gini.android.authorization.SharedPreferencesCredentialsStore;
+import net.gini.android.authorization.EncryptedCredentialsStore;
 import net.gini.android.authorization.UserCredentials;
 import net.gini.android.helpers.TestUtils;
 import net.gini.android.models.Document;
@@ -155,7 +155,7 @@ public class SdkIntegrationTest extends AndroidTestCase {
     }
 
     public void testDocumentUploadWorksAfterNewUserWasCreatedIfUserWasInvalid() throws IOException, JSONException, InterruptedException {
-        SharedPreferencesCredentialsStore credentialsStore = new SharedPreferencesCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE));
+        EncryptedCredentialsStore credentialsStore = new EncryptedCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE), getContext());
         gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
                 setApiBaseUrl(apiUri).
                 setUserCenterApiBaseUrl(userCenterUri).
@@ -181,7 +181,7 @@ public class SdkIntegrationTest extends AndroidTestCase {
 
     public void testEmailDomainIsUpdatedForExistingUserIfEmailDomainWasChanged() throws IOException, JSONException, InterruptedException {
         // Upload a document to make sure we have a valid user
-        SharedPreferencesCredentialsStore credentialsStore = new SharedPreferencesCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE));
+        EncryptedCredentialsStore credentialsStore = new EncryptedCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE), getContext());
         gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
                 setApiBaseUrl(apiUri).
                 setUserCenterApiBaseUrl(userCenterUri).

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/AnonymousSessionManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/AnonymousSessionManagerTest.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 import bolts.Task;
 
 @MediumTest
-public class AnonymousSessionManagerTests extends InstrumentationTestCase {
+public class AnonymousSessionManagerTest extends InstrumentationTestCase {
     private AnonymousSessionManager mAnonymousSessionSessionManager;
     private UserCenterManager mUserCenterManager;
     private CredentialsStore mCredentialsStore;

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -1,0 +1,124 @@
+package net.gini.android.authorization;
+
+import static android.content.Context.MODE_PRIVATE;
+
+import android.content.SharedPreferences;
+import android.test.AndroidTestCase;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class EncryptedCredentialsStoreTest extends AndroidTestCase {
+
+    private SharedPreferences mSharedPreferences;
+    private EncryptedCredentialsStore mCredentialsStore;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mSharedPreferences = getContext().getSharedPreferences("GiniTests", MODE_PRIVATE);
+        mSharedPreferences.edit().clear().commit();
+
+        mCredentialsStore = new EncryptedCredentialsStore(mSharedPreferences, getContext());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        mSharedPreferences.edit().clear().commit();
+    }
+
+    public void testEncryptsExistingPlaintextCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.mSharedPreferencesCredentialsStore.storeUserCredentials(userCredentials);
+        // When
+        mCredentialsStore.encryptExistingCredentials();
+        // Then
+        final UserCredentials encryptedUserCredentials =
+                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
+        assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
+    }
+
+    public void testDecryptsEncryptedExistingPlaintextCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.mSharedPreferencesCredentialsStore.storeUserCredentials(userCredentials);
+        // When
+        mCredentialsStore.encryptExistingCredentials();
+        // Then
+        final UserCredentials decryptedUserCredentials = mCredentialsStore.getUserCredentials();
+        assertEquals(userCredentials.getUsername(), decryptedUserCredentials.getUsername());
+        assertEquals(userCredentials.getPassword(), decryptedUserCredentials.getPassword());
+    }
+
+
+    public void testDoesNotEncryptAlreadyEncryptedCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        final UserCredentials encrpytedUserCredentialsBefore =
+                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        // When
+        mCredentialsStore.encryptExistingCredentials();
+        // Then
+        final UserCredentials encrpytedUserCredentialsAfter =
+                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        assertEquals(encrpytedUserCredentialsBefore.getUsername(),
+                encrpytedUserCredentialsAfter.getUsername());
+        assertEquals(encrpytedUserCredentialsBefore.getPassword(),
+                encrpytedUserCredentialsAfter.getPassword());
+    }
+
+    public void testEncryptsCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        // Then
+        final UserCredentials encryptedUserCredentials =
+                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
+        assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
+    }
+
+    public void testDecryptsCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        // When
+        final UserCredentials decryptedUserCredentials = mCredentialsStore.getUserCredentials();
+        // Then
+        assertEquals(userCredentials.getUsername(), decryptedUserCredentials.getUsername());
+        assertEquals(userCredentials.getPassword(), decryptedUserCredentials.getPassword());
+    }
+
+    public void testDeleteCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        // When
+        mCredentialsStore.deleteUserCredentials();
+        // Then
+        assertNull(mCredentialsStore.getUserCredentials());
+    }
+
+    public void testSetsEncryptedFlag() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        // Then
+        final boolean encryptedFlag = mCredentialsStore.mSharedPreferences.getBoolean(
+                EncryptedCredentialsStore.ENCRYPTED_KEY, false);
+        assertTrue(encryptedFlag);
+    }
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -57,23 +57,22 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         assertEquals(userCredentials.getPassword(), decryptedUserCredentials.getPassword());
     }
 
-
     public void testDoesNotEncryptAlreadyEncryptedCredentials() {
         // Given
         final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
                 "12345678");
         mCredentialsStore.storeUserCredentials(userCredentials);
-        final UserCredentials encrpytedUserCredentialsBefore =
+        final UserCredentials encryptedUserCredentialsBefore =
                 mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
         // When
         mCredentialsStore.encryptExistingCredentials();
         // Then
-        final UserCredentials encrpytedUserCredentialsAfter =
+        final UserCredentials encryptedUserCredentialsAfter =
                 mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
-        assertEquals(encrpytedUserCredentialsBefore.getUsername(),
-                encrpytedUserCredentialsAfter.getUsername());
-        assertEquals(encrpytedUserCredentialsBefore.getPassword(),
-                encrpytedUserCredentialsAfter.getPassword());
+        assertEquals(encryptedUserCredentialsBefore.getUsername(),
+                encryptedUserCredentialsAfter.getUsername());
+        assertEquals(encryptedUserCredentialsBefore.getPassword(),
+                encryptedUserCredentialsAfter.getPassword());
     }
 
     public void testEncryptsCredentials() {

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -36,7 +36,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
                 "12345678");
         mCredentialsStore.storeUserCredentialsWithoutEncryption(userCredentials);
         // When
-        mCredentialsStore.encryptExistingCredentials();
+        mCredentialsStore.encryptExistingPlaintextCredentials();
         // Then
         final UserCredentials encryptedUserCredentials =
                 mCredentialsStore.getEncryptedUserCredentials();
@@ -50,7 +50,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
                 "12345678");
         mCredentialsStore.storeUserCredentialsWithoutEncryption(userCredentials);
         // When
-        mCredentialsStore.encryptExistingCredentials();
+        mCredentialsStore.encryptExistingPlaintextCredentials();
         // Then
         final UserCredentials decryptedUserCredentials = mCredentialsStore.getUserCredentials();
         assertEquals(userCredentials.getUsername(), decryptedUserCredentials.getUsername());
@@ -65,7 +65,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         final UserCredentials encryptedUserCredentialsBefore =
                 mCredentialsStore.getEncryptedUserCredentials();
         // When
-        mCredentialsStore.encryptExistingCredentials();
+        mCredentialsStore.encryptExistingPlaintextCredentials();
         // Then
         final UserCredentials encryptedUserCredentialsAfter =
                 mCredentialsStore.getEncryptedUserCredentials();

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -5,6 +5,8 @@ import static android.content.Context.MODE_PRIVATE;
 import android.content.SharedPreferences;
 import android.test.AndroidTestCase;
 
+import net.gini.android.authorization.crypto.GiniCryptoHelper;
+
 /**
  * Created by Alpar Szotyori on 08.10.2018.
  *
@@ -132,6 +134,17 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         // Then
         assertTrue(!encryptedCredentials1.getUsername().equals(encryptedCredentials2.getUsername()));
         assertTrue(!encryptedCredentials1.getPassword().equals(encryptedCredentials2.getPassword()));
+    }
 
+    public void testReturnsNullCredentialsIfTheEncryptionKeyChanged() throws Exception {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        // When
+        GiniCryptoHelper.deleteSecretKey(mCredentialsStore.getGiniCrypto());
+        // Then
+        final UserCredentials encryptedUserCredentials = mCredentialsStore.getUserCredentials();
+        assertNull(encryptedUserCredentials);
     }
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -34,12 +34,12 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         // Given
         final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
                 "12345678");
-        mCredentialsStore.mSharedPreferencesCredentialsStore.storeUserCredentials(userCredentials);
+        mCredentialsStore.storeUserCredentialsWithoutEncryption(userCredentials);
         // When
         mCredentialsStore.encryptExistingCredentials();
         // Then
         final UserCredentials encryptedUserCredentials =
-                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+                mCredentialsStore.getEncryptedUserCredentials();
         assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
         assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
     }
@@ -48,7 +48,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         // Given
         final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
                 "12345678");
-        mCredentialsStore.mSharedPreferencesCredentialsStore.storeUserCredentials(userCredentials);
+        mCredentialsStore.storeUserCredentialsWithoutEncryption(userCredentials);
         // When
         mCredentialsStore.encryptExistingCredentials();
         // Then
@@ -63,12 +63,12 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
                 "12345678");
         mCredentialsStore.storeUserCredentials(userCredentials);
         final UserCredentials encryptedUserCredentialsBefore =
-                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+                mCredentialsStore.getEncryptedUserCredentials();
         // When
         mCredentialsStore.encryptExistingCredentials();
         // Then
         final UserCredentials encryptedUserCredentialsAfter =
-                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+                mCredentialsStore.getEncryptedUserCredentials();
         assertEquals(encryptedUserCredentialsBefore.getUsername(),
                 encryptedUserCredentialsAfter.getUsername());
         assertEquals(encryptedUserCredentialsBefore.getPassword(),
@@ -82,7 +82,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         mCredentialsStore.storeUserCredentials(userCredentials);
         // Then
         final UserCredentials encryptedUserCredentials =
-                mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+                mCredentialsStore.getEncryptedUserCredentials();
         assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
         assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
     }
@@ -116,8 +116,7 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
                 "12345678");
         mCredentialsStore.storeUserCredentials(userCredentials);
         // Then
-        final int encryptionVersion = mCredentialsStore.mSharedPreferences.getInt(
-                EncryptedCredentialsStore.ENCRYPTION_VERSION_KEY, 0);
+        final int encryptionVersion = mCredentialsStore.getEncryptionVersion();
         assertEquals(encryptionVersion, EncryptedCredentialsStore.ENCRYPTION_VERSION);
     }
 
@@ -126,10 +125,10 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
                 "12345678");
         mCredentialsStore.storeUserCredentials(userCredentials);
-        final UserCredentials encryptedCredentials1 = mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        final UserCredentials encryptedCredentials1 = mCredentialsStore.getEncryptedUserCredentials();
         // When
         mCredentialsStore.storeUserCredentials(userCredentials);
-        final UserCredentials encryptedCredentials2 = mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        final UserCredentials encryptedCredentials2 = mCredentialsStore.getEncryptedUserCredentials();
         // Then
         assertTrue(!encryptedCredentials1.getUsername().equals(encryptedCredentials2.getUsername()));
         assertTrue(!encryptedCredentials1.getPassword().equals(encryptedCredentials2.getPassword()));

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/EncryptedCredentialsStoreTest.java
@@ -111,14 +111,29 @@ public class EncryptedCredentialsStoreTest extends AndroidTestCase {
         assertNull(mCredentialsStore.getUserCredentials());
     }
 
-    public void testSetsEncryptedFlag() {
+    public void testSetsEncryptionVersion() {
         // Given
         final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
                 "12345678");
         mCredentialsStore.storeUserCredentials(userCredentials);
         // Then
-        final boolean encryptedFlag = mCredentialsStore.mSharedPreferences.getBoolean(
-                EncryptedCredentialsStore.ENCRYPTED_KEY, false);
-        assertTrue(encryptedFlag);
+        final int encryptionVersion = mCredentialsStore.mSharedPreferences.getInt(
+                EncryptedCredentialsStore.ENCRYPTION_VERSION_KEY, 0);
+        assertEquals(encryptionVersion, EncryptedCredentialsStore.ENCRYPTION_VERSION);
+    }
+
+    public void testEncryptionIsDifferentForSameCredentials() {
+        // Given
+        final UserCredentials userCredentials = new UserCredentials("testuser@gini.net",
+                "12345678");
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        final UserCredentials encryptedCredentials1 = mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        // When
+        mCredentialsStore.storeUserCredentials(userCredentials);
+        final UserCredentials encryptedCredentials2 = mCredentialsStore.mSharedPreferencesCredentialsStore.getUserCredentials();
+        // Then
+        assertTrue(!encryptedCredentials1.getUsername().equals(encryptedCredentials2.getUsername()));
+        assertTrue(!encryptedCredentials1.getPassword().equals(encryptedCredentials2.getPassword()));
+
     }
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/SharedPreferencesCredentialsStoreTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/SharedPreferencesCredentialsStoreTest.java
@@ -8,7 +8,7 @@ import android.support.test.filters.SmallTest;
 import android.test.AndroidTestCase;
 
 @SmallTest
-public class SharedPreferencesCredentialsStoreTests extends AndroidTestCase {
+public class SharedPreferencesCredentialsStoreTest extends AndroidTestCase {
 
     private SharedPreferencesCredentialsStore mCredentialsStore;
     private SharedPreferences mSharedPreferences;

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/crypto/GiniCryptoHelper.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/crypto/GiniCryptoHelper.java
@@ -1,0 +1,22 @@
+package net.gini.android.authorization.crypto;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+/**
+ * Created by Alpar Szotyori on 09.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class GiniCryptoHelper {
+
+    public static void deleteSecretKey(@NonNull final GiniCrypto giniCrypto)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        giniCrypto.deleteSecretKey();
+    }
+
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/models/DocumentTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/models/DocumentTest.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Date;
 
 @SmallTest
-public class DocumentTests extends AndroidTestCase {
+public class DocumentTest extends AndroidTestCase {
 
     private JSONObject createDocumentJSON() throws IOException, JSONException {
         return createDocumentJSON("document.json");

--- a/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
@@ -251,7 +251,7 @@ public class SdkBuilder {
     /**
      * Helper method to create (and store) the instance of the CredentialsStore implementation which is used to store
      * user credentials. If the credentials store was previously configured via the builder, the previously configured
-     * instance is used. Otherwise, a net.gini.android.authorization.SharedPreferencesCredentialsStore instance is
+     * instance is used. Otherwise, a net.gini.android.authorization.EncryptedCredentialsStore instance is
      * created by default.
      *
      * @return The CredentialsStore instance.
@@ -261,7 +261,10 @@ public class SdkBuilder {
         if (mCredentialsStore == null) {
             SharedPreferences sharedPreferences = mContext.getSharedPreferences("Gini",
                     Context.MODE_PRIVATE);
-            mCredentialsStore = new EncryptedCredentialsStore(sharedPreferences, mContext);
+            final EncryptedCredentialsStore encryptedCredentialsStore = new EncryptedCredentialsStore(
+                    sharedPreferences, mContext);
+            encryptedCredentialsStore.encryptExistingPlaintextCredentials();
+            mCredentialsStore = encryptedCredentialsStore;
         }
         return mCredentialsStore;
     }

--- a/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
@@ -13,8 +13,8 @@ import com.android.volley.RequestQueue;
 
 import net.gini.android.authorization.AnonymousSessionManager;
 import net.gini.android.authorization.CredentialsStore;
+import net.gini.android.authorization.EncryptedCredentialsStore;
 import net.gini.android.authorization.SessionManager;
-import net.gini.android.authorization.SharedPreferencesCredentialsStore;
 import net.gini.android.authorization.UserCenterAPICommunicator;
 import net.gini.android.authorization.UserCenterManager;
 import net.gini.android.requests.DefaultRetryPolicyFactory;
@@ -261,7 +261,7 @@ public class SdkBuilder {
         if (mCredentialsStore == null) {
             SharedPreferences sharedPreferences = mContext.getSharedPreferences("Gini",
                     Context.MODE_PRIVATE);
-            mCredentialsStore = new SharedPreferencesCredentialsStore(sharedPreferences);
+            mCredentialsStore = new EncryptedCredentialsStore(sharedPreferences, mContext);
         }
         return mCredentialsStore;
     }

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -17,13 +17,12 @@ import net.gini.android.authorization.crypto.GiniCryptoException;
  */
 public class EncryptedCredentialsStore implements CredentialsStore {
 
-    static final String ENCRYPTION_VERSION_KEY = "GiniEncryptionVersion";
+    @VisibleForTesting
     static final int ENCRYPTION_VERSION = 1;
-
-    @VisibleForTesting
-    final SharedPreferences mSharedPreferences;
-    @VisibleForTesting
-    final SharedPreferencesCredentialsStore mSharedPreferencesCredentialsStore;
+    private static final String ENCRYPTION_VERSION_KEY = "GiniEncryptionVersion";
+    
+    private final SharedPreferences mSharedPreferences;
+    private final SharedPreferencesCredentialsStore mSharedPreferencesCredentialsStore;
     private final GiniCrypto mCrypto;
 
     public EncryptedCredentialsStore(@NonNull final SharedPreferences sharedPreferences,
@@ -48,18 +47,6 @@ public class EncryptedCredentialsStore implements CredentialsStore {
         return mSharedPreferences.getInt(ENCRYPTION_VERSION_KEY, 0) != 0;
     }
 
-    private void setEncryptionVersion() {
-        mSharedPreferences.edit()
-                .putInt(ENCRYPTION_VERSION_KEY, ENCRYPTION_VERSION)
-                .apply();
-    }
-
-    private void removeEncryptionVersion() {
-        mSharedPreferences.edit()
-                .remove(ENCRYPTION_VERSION_KEY)
-                .apply();
-    }
-
     @Override
     public boolean storeUserCredentials(UserCredentials userCredentials) {
         try {
@@ -75,6 +62,12 @@ public class EncryptedCredentialsStore implements CredentialsStore {
         } catch (GiniCryptoException ignored) {
         }
         return false;
+    }
+
+    private void setEncryptionVersion() {
+        mSharedPreferences.edit()
+                .putInt(ENCRYPTION_VERSION_KEY, ENCRYPTION_VERSION)
+                .apply();
     }
 
     @Override
@@ -95,5 +88,26 @@ public class EncryptedCredentialsStore implements CredentialsStore {
     public boolean deleteUserCredentials() {
         removeEncryptionVersion();
         return mSharedPreferencesCredentialsStore.deleteUserCredentials();
+    }
+
+    private void removeEncryptionVersion() {
+        mSharedPreferences.edit()
+                .remove(ENCRYPTION_VERSION_KEY)
+                .apply();
+    }
+
+    @VisibleForTesting
+    UserCredentials getEncryptedUserCredentials() {
+        return mSharedPreferencesCredentialsStore.getUserCredentials();
+    }
+
+    @VisibleForTesting
+    void storeUserCredentialsWithoutEncryption(@NonNull final UserCredentials userCredentials) {
+        mSharedPreferencesCredentialsStore.storeUserCredentials(userCredentials);
+    }
+
+    @VisibleForTesting
+    int getEncryptionVersion() {
+        return mSharedPreferences.getInt(ENCRYPTION_VERSION_KEY, 0);
     }
 }

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -39,6 +39,11 @@ public class EncryptedCredentialsStore implements CredentialsStore {
         }
     }
 
+    @VisibleForTesting
+    GiniCrypto getGiniCrypto() {
+        return mCrypto;
+    }
+
     private boolean isEncrypted() {
         return mSharedPreferences.getInt(ENCRYPTION_VERSION_KEY, 0) != 0;
     }

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -29,11 +29,9 @@ public class EncryptedCredentialsStore implements CredentialsStore {
         mSharedPreferencesCredentialsStore = new SharedPreferencesCredentialsStore(
                 sharedPreferences);
         mCrypto = GiniCrypto.newInstance(sharedPreferences, context);
-        encryptExistingCredentials();
     }
 
-    @VisibleForTesting
-    void encryptExistingCredentials() {
+    public void encryptExistingPlaintextCredentials() {
         final UserCredentials userCredentials =
                 mSharedPreferencesCredentialsStore.getUserCredentials();
         if (userCredentials != null && !isEncrypted()) {

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -1,7 +1,5 @@
 package net.gini.android.authorization;
 
-import static net.gini.android.Utils.checkNotNull;
-
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
@@ -27,7 +25,7 @@ public class EncryptedCredentialsStore implements CredentialsStore {
 
     public EncryptedCredentialsStore(@NonNull final SharedPreferences sharedPreferences,
             @NonNull final Context context) {
-        mSharedPreferences = checkNotNull(sharedPreferences);
+        mSharedPreferences = sharedPreferences;
         mSharedPreferencesCredentialsStore = new SharedPreferencesCredentialsStore(
                 sharedPreferences);
         mCrypto = GiniCrypto.newInstance(sharedPreferences, context);

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -1,0 +1,99 @@
+package net.gini.android.authorization;
+
+import static net.gini.android.Utils.checkNotNull;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import net.gini.android.authorization.crypto.GiniCrypto;
+import net.gini.android.authorization.crypto.GiniCryptoException;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class EncryptedCredentialsStore implements CredentialsStore {
+
+    static final String ENCRYPTED_KEY = "GiniEncrypted";
+
+    @VisibleForTesting
+    final SharedPreferences mSharedPreferences;
+    @VisibleForTesting
+    final SharedPreferencesCredentialsStore mSharedPreferencesCredentialsStore;
+    private final GiniCrypto mCrypto;
+
+    public EncryptedCredentialsStore(@NonNull final SharedPreferences sharedPreferences,
+            @NonNull final Context context) {
+        mSharedPreferences = checkNotNull(sharedPreferences);
+        mSharedPreferencesCredentialsStore = new SharedPreferencesCredentialsStore(
+                sharedPreferences);
+        mCrypto = GiniCrypto.newInstance(sharedPreferences, context);
+        encryptExistingCredentials();
+    }
+
+    @VisibleForTesting
+    void encryptExistingCredentials() {
+        final UserCredentials userCredentials =
+                mSharedPreferencesCredentialsStore.getUserCredentials();
+        if (userCredentials != null && !isEncrypted()) {
+            storeUserCredentials(userCredentials);
+        }
+    }
+
+    private boolean isEncrypted() {
+        return mSharedPreferences.getBoolean(ENCRYPTED_KEY, false);
+    }
+
+    private void setEncryptedFlag() {
+        mSharedPreferences.edit()
+                .putBoolean(ENCRYPTED_KEY, true)
+                .apply();
+    }
+
+    private void removeEncryptedFlag() {
+        mSharedPreferences.edit()
+                .remove(ENCRYPTED_KEY)
+                .apply();
+    }
+
+    @Override
+    public boolean storeUserCredentials(UserCredentials userCredentials) {
+        final UserCredentials encryptedUserCredentials;
+        try {
+            encryptedUserCredentials = new UserCredentials(
+                    mCrypto.encrypt(userCredentials.getUsername()),
+                    mCrypto.encrypt(userCredentials.getPassword()));
+            final boolean stored = mSharedPreferencesCredentialsStore.storeUserCredentials(
+                    encryptedUserCredentials);
+            if (stored) {
+                setEncryptedFlag();
+            }
+            return stored;
+        } catch (GiniCryptoException ignored) {
+        }
+        return false;
+    }
+
+    @Override
+    public UserCredentials getUserCredentials() {
+        final UserCredentials encryptedUserCredentials =
+                mSharedPreferencesCredentialsStore.getUserCredentials();
+        if (encryptedUserCredentials != null) {
+            try {
+                return new UserCredentials(mCrypto.decrypt(encryptedUserCredentials.getUsername()),
+                        mCrypto.decrypt(encryptedUserCredentials.getPassword()));
+            } catch (GiniCryptoException ignored) {
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean deleteUserCredentials() {
+        removeEncryptedFlag();
+        return mSharedPreferencesCredentialsStore.deleteUserCredentials();
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/authorization/SharedPreferencesCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/SharedPreferencesCredentialsStore.java
@@ -1,15 +1,15 @@
 package net.gini.android.authorization;
 
+import static net.gini.android.Utils.checkNotNull;
+
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-
-import static net.gini.android.Utils.checkNotNull;
 
 
 public class SharedPreferencesCredentialsStore implements CredentialsStore {
 
-    protected static final String USERNAME_KEY = "GiniUsername";
-    protected static final String PASSWORD_KEY = "GiniPassword";
+    static final String USERNAME_KEY = "GiniUsername";
+    static final String PASSWORD_KEY = "GiniPassword";
 
     private final SharedPreferences mSharedPreferences;
 

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
@@ -20,6 +20,10 @@ import javax.crypto.IllegalBlockSizeException;
  */
 public abstract class GiniCrypto {
 
+    static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
+    static final String AES_MODE = "AES/GCM/NoPadding";
+
     public static GiniCrypto newInstance(@NonNull final SharedPreferences sharedPreferences,
             @NonNull final Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
@@ -4,10 +4,16 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 import android.util.Base64;
 
+import java.io.IOException;
 import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.cert.CertificateException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -40,28 +46,12 @@ public abstract class GiniCrypto {
             final byte[] encodedBytes = cipher.doFinal(text.getBytes());
             final byte[] encodedBytesWithIV = prependIV(iv, encodedBytes);
             return Base64.encodeToString(encodedBytesWithIV, Base64.DEFAULT);
-        } catch (IllegalBlockSizeException | BadPaddingException  e) {
-            throw new GiniCryptoException(e);
-        }
-    }
-
-    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
-        try {
-            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
-            final byte[] iv = readIV(encryptedBytes);
-            final Cipher cipher = createCipher(Cipher.DECRYPT_MODE, iv);
-            final int inputOffset = iv.length + 1;
-            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes, inputOffset,
-                    encryptedBytes.length - inputOffset);
-            return new String(decryptedBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException  e) {
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
             throw new GiniCryptoException(e);
         }
     }
 
     abstract Cipher createCipher(int cipherOpMode, @NonNull byte[] iv) throws GiniCryptoException;
-
-    abstract Key getSecretKey() throws GiniCryptoException;
 
     private byte[] prependIV(final byte[] iv, final byte[] encodedBytes) {
         final byte[] encodedBytesWithIV = new byte[encodedBytes.length + iv.length + 1];
@@ -79,10 +69,35 @@ public abstract class GiniCrypto {
         return iv;
     }
 
+    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
+        try {
+            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
+            final byte[] iv = readIV(encryptedBytes);
+            final Cipher cipher = createCipher(Cipher.DECRYPT_MODE, iv);
+            final int inputOffset = iv.length + 1;
+            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes, inputOffset,
+                    encryptedBytes.length - inputOffset);
+            return new String(decryptedBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
     private byte[] readIV(final byte[] encryptedBytes) {
         final byte[] iv = new byte[encryptedBytes[0]];
         System.arraycopy(encryptedBytes, 1, iv, 0, iv.length);
         return iv;
     }
+
+    abstract Key getSecretKey() throws GiniCryptoException;
+
+    @VisibleForTesting
+    void deleteSecretKey()
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        getKeyStore().deleteEntry(SECRET_KEY_ALIAS);
+    }
+
+    abstract KeyStore getKeyStore()
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException;
 
 }

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
@@ -1,0 +1,28 @@
+package net.gini.android.authorization.crypto;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public abstract class GiniCrypto {
+
+    public static GiniCrypto newInstance(@NonNull final SharedPreferences sharedPreferences,
+            @NonNull final Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new GiniCryptoAndroidMOrGreater();
+        } else {
+            return new GiniCryptoPreAndroidM(sharedPreferences, context);
+        }
+    }
+
+    public abstract String encrypt(@NonNull final String text) throws GiniCryptoException;
+
+    public abstract String decrypt(@NonNull final String encrypted) throws GiniCryptoException;
+
+}

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
@@ -4,6 +4,14 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.util.Base64;
+
+import java.security.Key;
+import java.security.SecureRandom;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
 
 /**
  * Created by Alpar Szotyori on 08.10.2018.
@@ -21,8 +29,56 @@ public abstract class GiniCrypto {
         }
     }
 
-    public abstract String encrypt(@NonNull final String text) throws GiniCryptoException;
+    public String encrypt(@NonNull final String text) throws GiniCryptoException {
+        try {
+            final byte[] iv = generateIV();
+            final Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, iv);
+            final byte[] encodedBytes = cipher.doFinal(text.getBytes());
+            final byte[] encodedBytesWithIV = prependIV(iv, encodedBytes);
+            return Base64.encodeToString(encodedBytesWithIV, Base64.DEFAULT);
+        } catch (IllegalBlockSizeException | BadPaddingException  e) {
+            throw new GiniCryptoException(e);
+        }
+    }
 
-    public abstract String decrypt(@NonNull final String encrypted) throws GiniCryptoException;
+    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
+        try {
+            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
+            final byte[] iv = readIV(encryptedBytes);
+            final Cipher cipher = createCipher(Cipher.DECRYPT_MODE, iv);
+            final int inputOffset = iv.length + 1;
+            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes, inputOffset,
+                    encryptedBytes.length - inputOffset);
+            return new String(decryptedBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException  e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
+    abstract Cipher createCipher(int cipherOpMode, @NonNull byte[] iv) throws GiniCryptoException;
+
+    abstract Key getSecretKey() throws GiniCryptoException;
+
+    private byte[] prependIV(final byte[] iv, final byte[] encodedBytes) {
+        final byte[] encodedBytesWithIV = new byte[encodedBytes.length + iv.length + 1];
+        encodedBytesWithIV[0] = (byte) iv.length;
+        System.arraycopy(iv, 0, encodedBytesWithIV, 1, iv.length);
+        System.arraycopy(encodedBytes, 0, encodedBytesWithIV, iv.length + 1,
+                encodedBytes.length);
+        return encodedBytesWithIV;
+    }
+
+    private byte[] generateIV() {
+        final SecureRandom secureRandom = new SecureRandom();
+        final byte[] iv = new byte[12];
+        secureRandom.nextBytes(iv);
+        return iv;
+    }
+
+    private byte[] readIV(final byte[] encryptedBytes) {
+        final byte[] iv = new byte[encryptedBytes[0]];
+        System.arraycopy(encryptedBytes, 1, iv, 0, iv.length);
+        return iv;
+    }
 
 }

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
@@ -28,11 +28,7 @@ import javax.crypto.spec.GCMParameterSpec;
  * Copyright (c) 2018 Gini GmbH.
  */
 @RequiresApi(api = Build.VERSION_CODES.M)
-public class GiniCryptoAndroidMOrGreater extends GiniCrypto {
-
-    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
-    private static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
-    private static final String AES_MODE = "AES/GCM/NoPadding";
+class GiniCryptoAndroidMOrGreater extends GiniCrypto {
 
     GiniCryptoAndroidMOrGreater() {
     }

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
@@ -1,0 +1,107 @@
+package net.gini.android.authorization.crypto;
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.util.Base64;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+@RequiresApi(api = Build.VERSION_CODES.M)
+public class GiniCryptoAndroidMOrGreater extends GiniCrypto {
+
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
+    private static final String AES_MODE = "AES/GCM/NoPadding";
+    private static final byte[] FIXED_IV = new byte[12];
+
+    @Override
+    public String encrypt(@NonNull final String text) throws GiniCryptoException {
+        try {
+            Cipher cipher = Cipher.getInstance(AES_MODE);
+            cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(), new GCMParameterSpec(128, FIXED_IV));
+            byte[] encodedBytes = cipher.doFinal(text.getBytes());
+            return Base64.encodeToString(encodedBytes, Base64.DEFAULT);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | KeyStoreException
+                | InvalidKeyException | InvalidAlgorithmParameterException
+                | UnrecoverableKeyException | BadPaddingException | NoSuchProviderException
+                | IllegalBlockSizeException | CertificateException | IOException e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
+    @Override
+    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
+        try {
+            Cipher cipher = Cipher.getInstance(AES_MODE);
+            cipher.init(Cipher.DECRYPT_MODE, getSecretKey(), new GCMParameterSpec(128, FIXED_IV));
+            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
+            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+            return new String(decryptedBytes);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | KeyStoreException
+                | InvalidKeyException | InvalidAlgorithmParameterException
+                | UnrecoverableKeyException | BadPaddingException | NoSuchProviderException
+                | IllegalBlockSizeException | CertificateException | IOException e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
+    private Key getSecretKey()
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException,
+            NoSuchProviderException, InvalidAlgorithmParameterException, UnrecoverableKeyException {
+        if (!hasSecretKey()) {
+            generateSecretKey();
+        }
+        return getKeyStore().getKey(SECRET_KEY_ALIAS, null);
+    }
+
+    private boolean hasSecretKey()
+            throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {
+        return getKeyStore().containsAlias(SECRET_KEY_ALIAS);
+    }
+
+    private KeyStore getKeyStore()
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+        keyStore.load(null);
+        return keyStore;
+    }
+
+    private void generateSecretKey() throws NoSuchProviderException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES,
+                ANDROID_KEY_STORE);
+        final KeyGenParameterSpec spec = new KeyGenParameterSpec
+                .Builder(SECRET_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(false)
+                .build();
+        keyGenerator.init(spec);
+        keyGenerator.generateKey();
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
@@ -64,7 +64,8 @@ class GiniCryptoAndroidMOrGreater extends GiniCrypto {
         return getKeyStore().containsAlias(SECRET_KEY_ALIAS);
     }
 
-    private KeyStore getKeyStore()
+    @Override
+    KeyStore getKeyStore()
             throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
         final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoException.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoException.java
@@ -1,0 +1,13 @@
+package net.gini.android.authorization.crypto;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class GiniCryptoException extends Exception {
+
+    GiniCryptoException(final Exception e) {
+        super(e);
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -35,13 +35,10 @@ import javax.security.auth.x500.X500Principal;
  *
  * Copyright (c) 2018 Gini GmbH.
  */
-public class GiniCryptoPreAndroidM extends GiniCrypto {
+class GiniCryptoPreAndroidM extends GiniCrypto {
 
-    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
-    private static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
     private static final String AES_KEY = "GiniKey";
     private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
-    private static final String AES_MODE = "AES/GCM/NoPadding";
 
     private final SharedPreferences mSharedPreferences;
     private final Context mContext;

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -19,7 +19,6 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.SecureRandom;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
 import java.util.Calendar;
@@ -27,7 +26,9 @@ import java.util.Calendar;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.x500.X500Principal;
 
@@ -42,54 +43,39 @@ public class GiniCryptoPreAndroidM extends GiniCrypto {
     private static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
     private static final String AES_KEY = "GiniKey";
     private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
-    private static final String AES_MODE = "AES/ECB/PKCS7Padding";
+    private static final String AES_MODE = "AES/GCM/NoPadding";
 
     private final SharedPreferences mSharedPreferences;
     private final Context mContext;
 
-    public GiniCryptoPreAndroidM(@NonNull final SharedPreferences sharedPreferences,
+    GiniCryptoPreAndroidM(@NonNull final SharedPreferences sharedPreferences,
             @NonNull final Context context) {
         mSharedPreferences = checkNotNull(sharedPreferences);
         mContext = checkNotNull(context);
     }
 
-    @Override
-    public String encrypt(@NonNull final String text) throws GiniCryptoException {
+    Cipher createCipher(int cipherOpMode, @NonNull byte[] iv)
+            throws GiniCryptoException {
         try {
-            final Cipher cipher = Cipher.getInstance(AES_MODE, "BC");
-            cipher.init(Cipher.ENCRYPT_MODE, getSecretKey());
-            final byte[] encodedBytes = cipher.doFinal(text.getBytes());
-            return Base64.encodeToString(encodedBytes, Base64.DEFAULT);
-        } catch (NoSuchProviderException | UnrecoverableEntryException | KeyStoreException
-                | NoSuchAlgorithmException | CertificateException | InvalidKeyException
-                | IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException
-                | IOException | InvalidAlgorithmParameterException e) {
+            final Cipher cipher = Cipher.getInstance(AES_MODE);
+            cipher.init(cipherOpMode, getSecretKey(), new IvParameterSpec(iv));
+            return cipher;
+        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException
+                | NoSuchAlgorithmException e) {
             throw new GiniCryptoException(e);
         }
     }
 
     @Override
-    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
+    Key getSecretKey() throws GiniCryptoException {
         try {
-            final Cipher cipher = Cipher.getInstance(AES_MODE, "BC");
-            cipher.init(Cipher.DECRYPT_MODE, getSecretKey());
-            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
-            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
-            return new String(decryptedBytes);
-        } catch (NoSuchProviderException | UnrecoverableEntryException | KeyStoreException
-                | NoSuchAlgorithmException | CertificateException | InvalidKeyException
-                | IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException
-                | IOException | InvalidAlgorithmParameterException e) {
+            return new SecretKeySpec(getAESKey(), "AES");
+        } catch (InvalidKeyException | UnrecoverableEntryException | NoSuchAlgorithmException
+                | KeyStoreException | NoSuchProviderException | InvalidAlgorithmParameterException
+                | CertificateException | IllegalBlockSizeException | BadPaddingException
+                | IOException | NoSuchPaddingException e) {
             throw new GiniCryptoException(e);
         }
-    }
-
-    private Key getSecretKey()
-            throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeyException,
-            NoSuchPaddingException, BadPaddingException,
-            UnrecoverableEntryException, KeyStoreException, NoSuchProviderException,
-            IllegalBlockSizeException, InvalidAlgorithmParameterException {
-        return new SecretKeySpec(getAESKey(), "AES");
     }
 
     private KeyStore getKeyStore()
@@ -114,11 +100,10 @@ public class GiniCryptoPreAndroidM extends GiniCrypto {
         }
     }
 
-    private byte[] generateAESKey() {
-        byte[] key = new byte[16];
-        SecureRandom secureRandom = new SecureRandom();
-        secureRandom.nextBytes(key);
-        return key;
+    private byte[] generateAESKey() throws NoSuchAlgorithmException {
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+        keyGenerator.init(256);
+        return keyGenerator.generateKey().getEncoded();
     }
 
     private void saveAESKey(@NonNull final byte[] aesKey)

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -1,7 +1,5 @@
 package net.gini.android.authorization.crypto;
 
-import static net.gini.android.Utils.checkNotNull;
-
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.security.KeyPairGeneratorSpec;
@@ -50,8 +48,8 @@ public class GiniCryptoPreAndroidM extends GiniCrypto {
 
     GiniCryptoPreAndroidM(@NonNull final SharedPreferences sharedPreferences,
             @NonNull final Context context) {
-        mSharedPreferences = checkNotNull(sharedPreferences);
-        mContext = checkNotNull(context);
+        mSharedPreferences = sharedPreferences;
+        mContext = context;
     }
 
     Cipher createCipher(int cipherOpMode, @NonNull byte[] iv)

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -1,0 +1,192 @@
+package net.gini.android.authorization.crypto;
+
+import static net.gini.android.Utils.checkNotNull;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.KeyPairGeneratorSpec;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import android.util.Base64;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+import java.util.Calendar;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * Created by Alpar Szotyori on 08.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class GiniCryptoPreAndroidM extends GiniCrypto {
+
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
+    private static final String AES_KEY = "GiniKey";
+    private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
+    private static final String AES_MODE = "AES/ECB/PKCS7Padding";
+
+    private final SharedPreferences mSharedPreferences;
+    private final Context mContext;
+
+    public GiniCryptoPreAndroidM(@NonNull final SharedPreferences sharedPreferences,
+            @NonNull final Context context) {
+        mSharedPreferences = checkNotNull(sharedPreferences);
+        mContext = checkNotNull(context);
+    }
+
+    @Override
+    public String encrypt(@NonNull final String text) throws GiniCryptoException {
+        try {
+            final Cipher cipher = Cipher.getInstance(AES_MODE, "BC");
+            cipher.init(Cipher.ENCRYPT_MODE, getSecretKey());
+            final byte[] encodedBytes = cipher.doFinal(text.getBytes());
+            return Base64.encodeToString(encodedBytes, Base64.DEFAULT);
+        } catch (NoSuchProviderException | UnrecoverableEntryException | KeyStoreException
+                | NoSuchAlgorithmException | CertificateException | InvalidKeyException
+                | IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException
+                | IOException | InvalidAlgorithmParameterException e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
+    @Override
+    public String decrypt(@NonNull final String encrypted) throws GiniCryptoException {
+        try {
+            final Cipher cipher = Cipher.getInstance(AES_MODE, "BC");
+            cipher.init(Cipher.DECRYPT_MODE, getSecretKey());
+            final byte[] encryptedBytes = Base64.decode(encrypted, Base64.DEFAULT);
+            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+            return new String(decryptedBytes);
+        } catch (NoSuchProviderException | UnrecoverableEntryException | KeyStoreException
+                | NoSuchAlgorithmException | CertificateException | InvalidKeyException
+                | IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException
+                | IOException | InvalidAlgorithmParameterException e) {
+            throw new GiniCryptoException(e);
+        }
+    }
+
+    private Key getSecretKey()
+            throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+            NoSuchPaddingException, BadPaddingException,
+            UnrecoverableEntryException, KeyStoreException, NoSuchProviderException,
+            IllegalBlockSizeException, InvalidAlgorithmParameterException {
+        return new SecretKeySpec(getAESKey(), "AES");
+    }
+
+    private KeyStore getKeyStore()
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+        keyStore.load(null);
+        return keyStore;
+    }
+
+    private byte[] getAESKey() throws IOException, CertificateException, NoSuchAlgorithmException,
+            NoSuchProviderException, InvalidKeyException, NoSuchPaddingException,
+            BadPaddingException, UnrecoverableEntryException,
+            KeyStoreException, IllegalBlockSizeException, InvalidAlgorithmParameterException {
+        final String encryptedBase64 = mSharedPreferences.getString(AES_KEY, "");
+        if (TextUtils.isEmpty(encryptedBase64)) {
+            final byte[] aesKey = generateAESKey();
+            saveAESKey(aesKey);
+            return aesKey;
+        } else {
+            final byte[] encrypted = Base64.decode(encryptedBase64, Base64.DEFAULT);
+            return rsaDecrypt(encrypted);
+        }
+    }
+
+    private byte[] generateAESKey() {
+        byte[] key = new byte[16];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(key);
+        return key;
+    }
+
+    private void saveAESKey(@NonNull final byte[] aesKey)
+            throws CertificateException, NoSuchAlgorithmException,
+            InvalidKeyException, UnrecoverableEntryException, NoSuchPaddingException,
+            BadPaddingException, IOException, KeyStoreException, NoSuchProviderException,
+            IllegalBlockSizeException, InvalidAlgorithmParameterException {
+        final byte[] encrypted = rsaEncrypt(aesKey);
+        final String encryptedBase64 = Base64.encodeToString(encrypted, Base64.DEFAULT);
+        mSharedPreferences.edit()
+                .putString(AES_KEY, encryptedBase64)
+                .apply();
+    }
+
+    private byte[] rsaEncrypt(byte[] secret)
+            throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException,
+            InvalidKeyException, BadPaddingException, IllegalBlockSizeException,
+            CertificateException, UnrecoverableEntryException,
+            KeyStoreException, IOException, InvalidAlgorithmParameterException {
+        final KeyStore.PrivateKeyEntry privateKeyEntry = getKeyPair();
+        final Cipher cipher = Cipher.getInstance(RSA_MODE, "AndroidOpenSSL");
+        cipher.init(Cipher.ENCRYPT_MODE, privateKeyEntry.getCertificate().getPublicKey());
+        return cipher.doFinal(secret);
+    }
+
+    private byte[] rsaDecrypt(byte[] encrypted)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
+            UnrecoverableEntryException, IOException, NoSuchProviderException,
+            NoSuchPaddingException, InvalidKeyException, BadPaddingException,
+            IllegalBlockSizeException, InvalidAlgorithmParameterException {
+        final KeyStore.PrivateKeyEntry privateKeyEntry = getKeyPair();
+        final Cipher cipher = Cipher.getInstance(RSA_MODE, "AndroidOpenSSL");
+        cipher.init(Cipher.DECRYPT_MODE, privateKeyEntry.getPrivateKey());
+        return cipher.doFinal(encrypted);
+    }
+
+    private KeyStore.PrivateKeyEntry getKeyPair()
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException,
+            NoSuchProviderException, InvalidAlgorithmParameterException,
+            UnrecoverableEntryException {
+        if (!hasKeyPair()) {
+            generateKeyPair();
+        }
+        return (KeyStore.PrivateKeyEntry) getKeyStore().getEntry(SECRET_KEY_ALIAS, null);
+    }
+
+    private boolean hasKeyPair()
+            throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {
+        return getKeyStore().containsAlias(SECRET_KEY_ALIAS);
+    }
+
+    private void generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException {
+        Calendar start = Calendar.getInstance();
+        Calendar end = Calendar.getInstance();
+        end.add(Calendar.YEAR, 30);
+
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA",
+                ANDROID_KEY_STORE);
+        final KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(mContext)
+                .setAlias(SECRET_KEY_ALIAS)
+                .setSubject(new X500Principal("CN=" + SECRET_KEY_ALIAS))
+                .setSerialNumber(BigInteger.TEN)
+                .setStartDate(start.getTime())
+                .setEndDate(end.getTime())
+                .build();
+        keyPairGenerator.initialize(spec);
+        keyPairGenerator.generateKeyPair();
+    }
+
+}

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -73,7 +73,8 @@ class GiniCryptoPreAndroidM extends GiniCrypto {
         }
     }
 
-    private KeyStore getKeyStore()
+    @Override
+    KeyStore getKeyStore()
             throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
         final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);


### PR DESCRIPTION
Before saving the anonymous credentials in the `SharedPreferences` we are encrypting them using AES encryption on API Level 23 (Android M) or later. On previous versions AES keys cannot be stored securely so we use RSA to encrypt the AES key before storing it in the `SharedPreferences`. The credentials are encrypted using this AES key.

In addition on API Levels 23+ more secure AES keys can be generated. On previous versions we deal with a less secure AES encryption, but rely on the `KeyStore` backed RSA private and public keys to keep our AES key secure.

Existing plain text credentials are replaced by their encrypted values.