### PR TITLE
Feature metadata headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
@@ -74,22 +74,22 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
 
     public void testUploadDocumentThrowsWithNullArguments() {
         try {
-            mApiCommunicator.uploadDocument(null, null, null, null, null);
+            mApiCommunicator.uploadDocument(null, null, null, null, null, null);
             fail("Exception not thrown");
         } catch(NullPointerException ignored) {}
 
         try {
-            mApiCommunicator.uploadDocument(null, "image/jpeg", null, null, createSession());
+            mApiCommunicator.uploadDocument(null, "image/jpeg", null, null, createSession(), null);
             fail("Exception not thrown");
         } catch (NullPointerException ignored) {}
 
         try {
-            mApiCommunicator.uploadDocument(createUploadData(), null, null, null, createSession());
+            mApiCommunicator.uploadDocument(createUploadData(), null, null, null, createSession(), null);
             fail("Exception not thrown");
         } catch (NullPointerException ignored) {}
 
         try {
-            mApiCommunicator.uploadDocument(createUploadData(), MediaTypes.IMAGE_JPEG, null, null, null);
+            mApiCommunicator.uploadDocument(createUploadData(), MediaTypes.IMAGE_JPEG, null, null, null, null);
             fail("Exception not thrown");
         } catch (NullPointerException ignored) {}
 
@@ -98,21 +98,21 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
     public void testUploadDocumentReturnsTask() {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
-        assertNotNull(mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session));
+        assertNotNull(mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null));
     }
 
     public void testUploadDocumentWithNameReturnsTask() {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        assertNotNull(mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, "foobar.jpg", session));
+        assertNotNull(mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, "foobar.jpg", session, null));
     }
 
     public void testUploadDocumentHasCorrectAccessToken() throws AuthFailureError {
         final byte[] documentData = createUploadData();
         final Session session = createSession("1234-5678");
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -124,7 +124,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -135,7 +135,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -148,7 +148,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -160,7 +160,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -174,7 +174,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, "foobar.jpg", null, session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, "foobar.jpg", null, session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -187,7 +187,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         final byte[] documentData = createUploadData();
         final Session session = createSession();
 
-        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, "invoice", session);
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, "invoice", session, null);
 
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
@@ -751,5 +751,31 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         verify(mRequestQueue).add(requestCaptor.capture());
         final Request request = requestCaptor.getValue();
         assertEquals("BEARER 9999-8888-7777", request.getHeaders().get("Authorization"));
+    }
+
+    public void testDocumentMetadataIsAddedToTheRequestHeaders() throws Exception {
+        final byte[] documentData = createUploadData();
+        final Session session = createSession();
+
+        final DocumentMetadata metadata = new DocumentMetadata();
+        final String branchId = "4321";
+        metadata.setBranchId(branchId);
+        final String customMetadataName = "Test";
+        final String customMetadataValue = "Unit";
+        metadata.add(customMetadataName, customMetadataValue);
+
+        mApiCommunicator.uploadDocument(documentData, MediaTypes.IMAGE_JPEG, null, null, session, metadata);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(mRequestQueue).add(requestCaptor.capture());
+        final Request request = requestCaptor.getValue();
+
+        assertTrue(request.getHeaders().containsKey(DocumentMetadata.BRANCH_ID_HEADER_FIELD_NAME));
+        String value = (String) request.getHeaders().get(DocumentMetadata.BRANCH_ID_HEADER_FIELD_NAME);
+        assertEquals(value, branchId);
+
+        assertTrue(request.getHeaders().containsKey(DocumentMetadata.HEADER_FIELD_NAME_PREFIX + customMetadataName));
+        value = (String) request.getHeaders().get(DocumentMetadata.HEADER_FIELD_NAME_PREFIX + customMetadataName);
+        assertEquals(value, customMetadataValue);
     }
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentMetadataTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentMetadataTest.java
@@ -1,0 +1,93 @@
+package net.gini.android;
+
+import android.support.test.filters.SmallTest;
+import android.test.InstrumentationTestCase;
+
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 25.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+@SmallTest
+public class DocumentMetadataTest extends InstrumentationTestCase {
+
+    private DocumentMetadata mDocumentMetadata;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mDocumentMetadata = new DocumentMetadata();
+    }
+
+    public void testBranchIdFieldName() {
+        final String branchId = "4321";
+        mDocumentMetadata.setBranchId(branchId);
+
+        assertFalse(mDocumentMetadata.getMetadata().isEmpty());
+        boolean containsBranchId = false;
+        for (final Map.Entry<String, String> entry : mDocumentMetadata.getMetadata().entrySet()) {
+            if (entry.getValue().equals(branchId)) {
+                containsBranchId = true;
+                final String fieldName = entry.getKey();
+                assertTrue(fieldName.startsWith(DocumentMetadata.HEADER_FIELD_NAME_PREFIX));
+                assertEquals(fieldName, DocumentMetadata.BRANCH_ID_HEADER_FIELD_NAME);
+            }
+        }
+        assertTrue(containsBranchId);
+    }
+
+    public void testBranchIdMustBeASCIIEncodable() {
+        IllegalArgumentException exception = null;
+        try {
+            mDocumentMetadata.setBranchId("Bräustüberl");
+        } catch (IllegalArgumentException e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+    }
+
+    public void testCustomFieldNameContainsHeaderPrefix() {
+        final String name = "App";
+        final String value = "DieBank";
+        mDocumentMetadata.add(name, value);
+
+        assertFalse(mDocumentMetadata.getMetadata().isEmpty());
+        boolean containsBranchId = false;
+        for (final Map.Entry<String, String> entry : mDocumentMetadata.getMetadata().entrySet()) {
+            if (entry.getValue().equals(value)) {
+                containsBranchId = true;
+                assertEquals(entry.getKey(), DocumentMetadata.HEADER_FIELD_NAME_PREFIX + name);
+            }
+        }
+        assertTrue(containsBranchId);
+    }
+
+    public void testCustomFieldNameMustBeASCIIEncodable() {
+        IllegalArgumentException exception = null;
+        try {
+            mDocumentMetadata.add("Übung", "Rumpfdrehen");
+        } catch (IllegalArgumentException e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+    }
+
+    public void testCustomFieldValueMustBeASCIIEncodable() {
+        IllegalArgumentException exception = null;
+        try {
+            mDocumentMetadata.add("App", "Fotoüberweisung");
+        } catch (IllegalArgumentException e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+    }
+
+    public void testAcceptsAllStringsWhenASCIIEncoderIsNotAvailable() {
+        final DocumentMetadata documentMetadata = new DocumentMetadata(null);
+        assertTrue(documentMetadata.isASCIIEncodable("Bräustüberl"));
+    }
+
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentMetadataTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentMetadataTest.java
@@ -33,7 +33,7 @@ public class DocumentMetadataTest extends InstrumentationTestCase {
                 containsBranchId = true;
                 final String fieldName = entry.getKey();
                 assertTrue(fieldName.startsWith(DocumentMetadata.HEADER_FIELD_NAME_PREFIX));
-                assertEquals(fieldName, DocumentMetadata.BRANCH_ID_HEADER_FIELD_NAME);
+                assertEquals(DocumentMetadata.BRANCH_ID_HEADER_FIELD_NAME ,fieldName);
             }
         }
         assertTrue(containsBranchId);
@@ -59,7 +59,23 @@ public class DocumentMetadataTest extends InstrumentationTestCase {
         for (final Map.Entry<String, String> entry : mDocumentMetadata.getMetadata().entrySet()) {
             if (entry.getValue().equals(value)) {
                 containsBranchId = true;
-                assertEquals(entry.getKey(), DocumentMetadata.HEADER_FIELD_NAME_PREFIX + name);
+                assertEquals(DocumentMetadata.HEADER_FIELD_NAME_PREFIX + name, entry.getKey());
+            }
+        }
+        assertTrue(containsBranchId);
+    }
+
+    public void testCustomFieldNameHeaderPrefixIsNotAddedTwice() {
+        final String name = DocumentMetadata.HEADER_FIELD_NAME_PREFIX + "App";
+        final String value = "DieBank";
+        mDocumentMetadata.add(name, value);
+
+        assertFalse(mDocumentMetadata.getMetadata().isEmpty());
+        boolean containsBranchId = false;
+        for (final Map.Entry<String, String> entry : mDocumentMetadata.getMetadata().entrySet()) {
+            if (entry.getValue().equals(value)) {
+                containsBranchId = true;
+                assertEquals(name, entry.getKey());
             }
         }
         assertTrue(containsBranchId);

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -177,7 +177,7 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
     public void testThatCreateDocumentResolvesToDocument() throws IOException, JSONException, InterruptedException {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class), any(String.class), any(String.class),
-                                             any(Session.class)))
+                                             any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(createdDocumentUri));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -193,7 +193,7 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
             throws IOException, JSONException, InterruptedException {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class), any(String.class), any(String.class),
-                                             any(Session.class)))
+                                             any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -203,14 +203,14 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
         verify(mApiCommunicator)
                 .uploadDocument(any(byte[].class), eq(MediaTypes.IMAGE_JPEG), eq("foobar.jpg"), eq("invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testThatCreatePartialDocumentSetsTheCorrectContentType() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
                 any(String.class), any(String.class),
-                any(Session.class)))
+                any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -223,14 +223,14 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                 .uploadDocument(eq(document),
                         eq("application/vnd.gini.v2.partial+jpeg"), eq("foobar.jpg"),
                         eq("Invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testThatCreateCompositeDocumentSetsTheCorrectContentType() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
                 any(String.class), any(String.class),
-                any(Session.class)))
+                any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -245,14 +245,14 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                 .uploadDocument(any(byte[].class),
                         eq("application/vnd.gini.v2.composite+json"), eq((String) null),
                         eq("Invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testThatCreateCompositeDocumentUploadsCorrectJson() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
                 any(String.class), any(String.class),
-                any(Session.class)))
+                any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -274,14 +274,14 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                 .uploadDocument(eq(jsonBytes),
                         eq("application/vnd.gini.v2.composite+json"), eq((String) null),
                         eq("Invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testThatCreateCompositeDocumentUploadsJsonWithRotation() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
                 any(String.class), any(String.class),
-                any(Session.class)))
+                any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -303,14 +303,14 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                 .uploadDocument(eq(jsonBytes),
                         eq("application/vnd.gini.v2.composite+json"), eq((String) null),
                         eq("Invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testThatCreateCompositeDocumentUploadsJsonWithNormalizedRotation() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
                 any(String.class), any(String.class),
-                any(Session.class)))
+                any(Session.class), any(DocumentMetadata.class)))
                 .thenReturn(Task.forResult(Uri.parse("https://api.gini.net/documents/1234")));
         when(mApiCommunicator.getDocument(eq(createdDocumentUri), any(Session.class))).thenReturn(
                 createDocumentJSONTask("1234"));
@@ -332,7 +332,7 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                 .uploadDocument(eq(jsonBytes),
                         eq("application/vnd.gini.v2.composite+json"), eq((String) null),
                         eq("Invoice"),
-                        eq(mSession));
+                        eq(mSession), any(DocumentMetadata.class));
     }
 
     public void testDeleteDocument() throws Exception {
@@ -734,4 +734,5 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
         assertNotNull(responseData);
     }
+
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
@@ -475,7 +475,7 @@ public class SdkIntegrationTest extends AndroidTestCase {
                         || amountToPay.equals("588.60:EUR")
                         || amountToPay.equals("700.43:EUR"));
         assertEquals("BIC should be found", "WELADED1MIN", extractions.get("bic").getValue());
-        assertEquals("Payee should be found", "Mindener Stadtwerke GmbH", extractions.get("paymentRecipient").getValue());
+        assertTrue("Payement recipient should be found", extractions.get("paymentRecipient").getValue().startsWith("Mindener Stadtwerke"));
         assertEquals("Payment reference should be found", "ReNr TST-00019, KdNr 765432", extractions.get("paymentReference").getValue());
 
         // all extractions are correct, that means we have nothing to correct and will only send positive feedback

--- a/ginisdk/src/doc/source/changelog.rst
+++ b/ginisdk/src/doc/source/changelog.rst
@@ -6,9 +6,9 @@ Changelog
 ==================
 
 - Anonymous user credentials are encrypted by default. Existing user credentials are automatically
-encrypted on first usage. IMPORTANT: This change affects how credentials are stored only if no
-custom CredentialsStore implementation was set. If you require encryption either don't use a custom
-CredentialsStore or use the ``EncryptedCredentialsStore``.
+  encrypted on first usage. IMPORTANT: This change affects how credentials are stored only if no
+  custom CredentialsStore implementation was set. If you require encryption either don't use a custom
+  CredentialsStore or use the ``EncryptedCredentialsStore``.
 - We raised the minimum Android SDK version to 19.
 
 2.0.1 (2018-09-18)

--- a/ginisdk/src/main/java/net/gini/android/ApiCommunicator.java
+++ b/ginisdk/src/main/java/net/gini/android/ApiCommunicator.java
@@ -27,6 +27,7 @@ import net.gini.android.requests.RetryPolicyFactory;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public class ApiCommunicator {
 
     public Task<Uri> uploadDocument(final byte[] documentData, final String contentType,
                                     @Nullable final String documentName, @Nullable final String docTypeHint,
-                                    final Session session) {
+                                    final Session session, @Nullable final DocumentMetadata documentMetadata) {
 
         final HashMap<String, String> requestQueryData = new HashMap<String, String>();
         if (documentName != null) {
@@ -67,9 +68,16 @@ public class ApiCommunicator {
         final String url = mBaseUri.buildUpon().path("documents/").encodedQuery(mapToUrlEncodedString(requestQueryData))
                 .toString();
         final RequestTaskCompletionSource<Uri> completionSource = RequestTaskCompletionSource.newCompletionSource();
+        final Map<String, String> metadata;
+        if (documentMetadata != null) {
+            metadata = documentMetadata.getMetadata();
+        } else {
+            metadata = Collections.emptyMap();
+        }
         final BearerUploadRequest request =
                 new BearerUploadRequest(POST, url, checkNotNull(documentData), checkNotNull(contentType), session,
-                        completionSource, completionSource, mRetryPolicyFactory.newRetryPolicy());
+                        completionSource, completionSource, mRetryPolicyFactory.newRetryPolicy(),
+                        metadata);
         mRequestQueue.add(request);
 
         return completionSource.getTask();

--- a/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
@@ -89,7 +89,13 @@ public class DocumentMetadata {
             throw new IllegalArgumentException(
                     "Metadata value is not encodable as ASCII: " + value);
         }
-        mMetadataMap.put(HEADER_FIELD_NAME_PREFIX + name, value);
+        final String completeName;
+        if (name.startsWith(HEADER_FIELD_NAME_PREFIX)) {
+            completeName = name;
+        } else {
+            completeName = HEADER_FIELD_NAME_PREFIX + name;
+        }
+        mMetadataMap.put(completeName, value);
     }
 
     @NonNull

--- a/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
@@ -14,6 +14,12 @@ import java.util.Map;
  *
  * Copyright (c) 2018 Gini GmbH.
  */
+
+/**
+ * Use this class to pass additional information for a document when uploading it to the Gini API.
+ *
+ * <p> Besides the predefined metadata fields you may also add custom fields.
+ */
 public class DocumentMetadata {
 
     @VisibleForTesting
@@ -25,6 +31,9 @@ public class DocumentMetadata {
     private final Map<String, String> mMetadataMap = new HashMap<>();
     private CharsetEncoder mAsciiCharsetEncoder;
 
+    /**
+     * Create a new instance.
+     */
     public DocumentMetadata() {
         try {
             final Charset asciiCharset = Charset.forName("ASCII");
@@ -40,6 +49,12 @@ public class DocumentMetadata {
         mAsciiCharsetEncoder = charsetEncoder;
     }
 
+    /**
+     * Set a branch identifier to associate the document with a particular branch.
+     *
+     * @param branchId an identifier as an ASCII compatible string
+     * @throws IllegalArgumentException if the branchId string cannot be encoded as ASCII
+     */
     public void setBranchId(@NonNull final String branchId) throws IllegalArgumentException {
         if (isASCIIEncodable(branchId)) {
             mMetadataMap.put(BRANCH_ID_HEADER_FIELD_NAME, branchId);
@@ -57,6 +72,14 @@ public class DocumentMetadata {
         return true;
     }
 
+    /**
+     * Add a custom metadata field. If there is already a field with the same name,
+     * the previous value will be overwritten with this one.
+     *
+     * @param name field name as an ASCII compatible string
+     * @param value field value as an ASCII compatible string
+     * @throws IllegalArgumentException if the name or the value cannot be encoded as ASCII
+     */
     public void add(@NonNull final String name, @NonNull final String value)
             throws IllegalArgumentException {
         if (!isASCIIEncodable(name)) {

--- a/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
@@ -1,0 +1,76 @@
+package net.gini.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 25.10.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class DocumentMetadata {
+
+    @VisibleForTesting
+    static final String HEADER_FIELD_NAME_PREFIX = "X-Document-Metadata-";
+    @VisibleForTesting
+    static final String BRANCH_ID_HEADER_FIELD_NAME = HEADER_FIELD_NAME_PREFIX + "BranchId";
+
+
+    private final Map<String, String> mMetadataMap = new HashMap<>();
+    private CharsetEncoder mAsciiCharsetEncoder;
+
+    public DocumentMetadata() {
+        try {
+            final Charset asciiCharset = Charset.forName("ASCII");
+            mAsciiCharsetEncoder = asciiCharset.newEncoder();
+        } catch (IllegalArgumentException ignore) {
+            // Shouldn't happen
+            mAsciiCharsetEncoder = null;
+        }
+    }
+
+    @VisibleForTesting
+    DocumentMetadata(@Nullable CharsetEncoder charsetEncoder) {
+        mAsciiCharsetEncoder = charsetEncoder;
+    }
+
+    public void setBranchId(@NonNull final String branchId) throws IllegalArgumentException {
+        if (isASCIIEncodable(branchId)) {
+            mMetadataMap.put(BRANCH_ID_HEADER_FIELD_NAME, branchId);
+        } else {
+            throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + branchId);
+        }
+    }
+
+    @VisibleForTesting
+    boolean isASCIIEncodable(@NonNull final String string) {
+        if (mAsciiCharsetEncoder != null) {
+            return mAsciiCharsetEncoder.canEncode(string);
+        }
+        // If no ASCII encoder (should never happen) then accept everything to not block metadata
+        return true;
+    }
+
+    public void add(@NonNull final String name, @NonNull final String value)
+            throws IllegalArgumentException {
+        if (!isASCIIEncodable(name)) {
+            throw new IllegalArgumentException("Metadata name is not encodable as ASCII: " + name);
+        }
+        if (!isASCIIEncodable(value)) {
+            throw new IllegalArgumentException(
+                    "Metadata value is not encodable as ASCII: " + value);
+        }
+        mMetadataMap.put(HEADER_FIELD_NAME_PREFIX + name, value);
+    }
+
+    @NonNull
+    Map<String, String> getMetadata() {
+        return mMetadataMap;
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/requests/BearerUploadRequest.java
+++ b/ginisdk/src/main/java/net/gini/android/requests/BearerUploadRequest.java
@@ -16,17 +16,20 @@ public class BearerUploadRequest extends BearerLocationRequest{
     private final byte[] mUploadData;
     private final String mContentType;
     private final String mAccessToken;
+    private final Map<String, String> mHeaders;
 
     public BearerUploadRequest(int method, String url, byte[] uploadData, String contentType,
-                               final Session session,
-                               Response.Listener<Uri> listener,
-                               Response.ErrorListener errorListener,
-                               RetryPolicy retryPolicy) {
+            final Session session,
+            Response.Listener<Uri> listener,
+            Response.ErrorListener errorListener,
+            RetryPolicy retryPolicy,
+            final Map<String, String> headers) {
         super(method, url, null, session, listener, errorListener, retryPolicy);
 
         mUploadData = uploadData;
         mContentType = contentType;
         mAccessToken = session.getAccessToken();
+        mHeaders = headers;
     }
 
     @Override
@@ -36,7 +39,7 @@ public class BearerUploadRequest extends BearerLocationRequest{
 
     @Override
     public Map<String, String> getHeaders() {
-        HashMap<String, String> headers = new HashMap<String, String>();
+        HashMap<String, String> headers = new HashMap<>(mHeaders);
         headers.put("Accept", String.format("%s, %s", MediaTypes.APPLICATION_JSON, MediaTypes.GINI_JSON_V2));
         headers.put("Authorization", "BEARER " + mAccessToken);
         return headers;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Metadata can be set for document uploads and these will be added to the request header fields.

Based on our [proposal](https://docs.google.com/document/d/1hm0QQJXQN0mNGvBD_XDRuGC6yuxQ-ctLHA_iUVEpock/edit#).