### PR TITLE
Accounting API support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
-                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
+                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestApiUriAccounting='https://accounting-api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
                     }
                 }
             }
@@ -57,7 +57,7 @@ pipeline {
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
-                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
+                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestApiUriAccounting='https://accounting-api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
                     }
                 }
             }
@@ -80,7 +80,7 @@ pipeline {
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
-                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
+                        sh "./gradlew ginisdk:targetedDebugAndroidTest -PpackageName=net.gini.android -PtestTarget=emulator-$emulatorPort -PtestClientId=$GINI_API_CREDENTIALS_USR -PtestClientSecret=$GINI_API_CREDENTIALS_PSW -PtestApiUri='https://api.gini.net' -PtestApiUriAccounting='https://accounting-api.gini.net' -PtestUserCenterUri='https://user.gini.net'"
                     }
                 }
             }

--- a/ginisdk/build.gradle
+++ b/ginisdk/build.gradle
@@ -81,6 +81,7 @@ task createTestPropertyFile {
         setProperty('testClientId', props, localProperties)
         setProperty('testClientSecret', props, localProperties)
         setProperty('testApiUri', props, localProperties)
+        setProperty('testApiUriAccounting', props, localProperties)
         setProperty('testUserCenterUri', props, localProperties)
 
         propertyFile.withWriter("utf-8") {

--- a/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/ApiCommunicatorTest.java
@@ -43,7 +43,7 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
         System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         retryPolicyFactory = new DefaultRetryPolicyFactory();
         mRequestQueue = Mockito.mock(RequestQueue.class);
-        mApiCommunicator = new ApiCommunicator("https://api.gini.net/", mRequestQueue, retryPolicyFactory);
+        mApiCommunicator = new ApiCommunicator("https://api.gini.net/", GiniApiType.DEFAULT, mRequestQueue, retryPolicyFactory);
     }
 
     public byte[] createUploadData() {
@@ -60,13 +60,13 @@ public class ApiCommunicatorTest extends InstrumentationTestCase {
 
     public void testConstructionThrowsNullPointerExceptionWithNullArguments() {
         try {
-            new ApiCommunicator(null, null, retryPolicyFactory);
+            new ApiCommunicator(null, null, null, retryPolicyFactory);
             fail("NullPointerException not thrown");
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new ApiCommunicator("https://api.gini.net", null, retryPolicyFactory);
+            new ApiCommunicator("https://api.gini.net", GiniApiType.DEFAULT, null, retryPolicyFactory);
             fail("NullPointerException not thrown");
         } catch (NullPointerException ignored) {
         }

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -57,7 +57,7 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
         mApiCommunicator = Mockito.mock(ApiCommunicator.class);
         mSessionManager = Mockito.mock(SessionManager.class);
-        mDocumentTaskManager = new DocumentTaskManager(mApiCommunicator, mSessionManager);
+        mDocumentTaskManager = new DocumentTaskManager(mApiCommunicator, mSessionManager, GiniApiType.DEFAULT);
 
         // Always mock the session away since it is not what is tested here.
         mSession = new Session("1234-5678-9012", new Date(new Date().getTime() + 10000));
@@ -156,13 +156,13 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
     public void testThatConstructorChecksForNull() {
         try {
-            new DocumentTaskManager(null, null);
+            new DocumentTaskManager(null, null, null);
             fail("Exception not thrown");
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new DocumentTaskManager(mApiCommunicator, null);
+            new DocumentTaskManager(mApiCommunicator, null, null);
             fail("Exception not thrown");
         } catch (NullPointerException ignored) {
         }

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -232,11 +232,11 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
 
         final byte[] document = new byte[] {0x01, 0x02};
 
-        IllegalStateException exception = null;
+        UnsupportedOperationException exception = null;
         try {
             documentTaskManager.createPartialDocument(document, MediaTypes.IMAGE_JPEG, "foobar.jpg",
                     DocumentType.INVOICE).waitForCompletion();
-        } catch (IllegalStateException e) {
+        } catch (UnsupportedOperationException e) {
             exception = e;
         }
 
@@ -361,10 +361,10 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
         partialDocuments.put(createDocument("1111"), -90);
         partialDocuments.put(createDocument("2222"), 450);
 
-        IllegalStateException exception = null;
+        UnsupportedOperationException exception = null;
         try {
             documentTaskManager.createCompositeDocument(partialDocuments, DocumentType.INVOICE).waitForCompletion();
-        } catch (IllegalStateException e) {
+        } catch (UnsupportedOperationException e) {
             exception = e;
         }
 

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -226,6 +226,24 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                         eq(mSession), any(DocumentMetadata.class));
     }
 
+    public void testThatCreatePartialDocumentThrowsExceptionWhenUsingAccountingApiType() throws Exception {
+        final DocumentTaskManager documentTaskManager =
+                new DocumentTaskManager(mApiCommunicator, mSessionManager, GiniApiType.ACCOUNTING);
+
+        final byte[] document = new byte[] {0x01, 0x02};
+
+        IllegalStateException exception = null;
+        try {
+            documentTaskManager.createPartialDocument(document, MediaTypes.IMAGE_JPEG, "foobar.jpg",
+                    DocumentType.INVOICE).waitForCompletion();
+        } catch (IllegalStateException e) {
+            exception = e;
+        }
+
+        assertNotNull(exception);
+        assertEquals("Partial documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.", exception.getMessage());
+    }
+
     public void testThatCreateCompositeDocumentSetsTheCorrectContentType() throws Exception {
         final Uri createdDocumentUri = Uri.parse("https://api.gini.net/documents/1234");
         when(mApiCommunicator.uploadDocument(any(byte[].class), any(String.class),
@@ -333,6 +351,25 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
                         eq("application/vnd.gini.v2.composite+json"), eq((String) null),
                         eq("Invoice"),
                         eq(mSession), any(DocumentMetadata.class));
+    }
+
+    public void testThatCreateCompositeDocumentThrowsExceptionWhenUsingAccountingApiType() throws Exception {
+        final DocumentTaskManager documentTaskManager =
+                new DocumentTaskManager(mApiCommunicator, mSessionManager, GiniApiType.ACCOUNTING);
+
+        final LinkedHashMap<Document, Integer> partialDocuments = new LinkedHashMap<>();
+        partialDocuments.put(createDocument("1111"), -90);
+        partialDocuments.put(createDocument("2222"), 450);
+
+        IllegalStateException exception = null;
+        try {
+            documentTaskManager.createCompositeDocument(partialDocuments, DocumentType.INVOICE).waitForCompletion();
+        } catch (IllegalStateException e) {
+            exception = e;
+        }
+
+        assertNotNull(exception);
+        assertEquals("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.", exception.getMessage());
     }
 
     public void testDeleteDocument() throws Exception {

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTestAccounting.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTestAccounting.java
@@ -1,0 +1,361 @@
+package net.gini.android;
+
+import static net.gini.android.helpers.TrustKitHelper.resetTrustKit;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import android.support.test.filters.LargeTest;
+import android.support.test.filters.SdkSuppress;
+import android.test.AndroidTestCase;
+import android.util.Log;
+
+import com.android.volley.toolbox.NoCache;
+
+import net.gini.android.DocumentTaskManager.DocumentUploadBuilder;
+import net.gini.android.authorization.EncryptedCredentialsStore;
+import net.gini.android.authorization.UserCredentials;
+import net.gini.android.helpers.TestUtils;
+import net.gini.android.models.Document;
+import net.gini.android.models.SpecificExtraction;
+
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import bolts.Continuation;
+import bolts.Task;
+
+@LargeTest
+public class SdkIntegrationTestAccounting extends AndroidTestCase {
+
+    private Gini gini;
+    private String clientId;
+    private String clientSecret;
+    private String apiUriAccounting;
+    private String userCenterUri;
+
+    @Override
+    protected void setUp() throws Exception {
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testPropertiesInput = assetManager.open("test.properties");
+        assertNotNull("test.properties not found", testPropertiesInput);
+        final Properties testProperties = new Properties();
+        testProperties.load(testPropertiesInput);
+        clientId = getProperty(testProperties, "testClientId");
+        clientSecret = getProperty(testProperties, "testClientSecret");
+        apiUriAccounting = getProperty(testProperties, "testApiUriAccounting");
+        userCenterUri = getProperty(testProperties, "testUserCenterUri");
+
+        Log.d("TEST", "testClientId " + clientId);
+        Log.d("TEST", "testClientSecret " + clientSecret);
+        Log.d("TEST", "testApiUriAccounting " + apiUriAccounting);
+        Log.d("TEST", "testUserCenterUri " + userCenterUri);
+
+        resetTrustKit();
+
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                build();
+    }
+
+    private static String getProperty(Properties properties, String propertyName) {
+        Object value = properties.get(propertyName);
+        assertNotNull(propertyName + " not set!", value);
+        return value.toString();
+    }
+
+    public void testDeprecatedProcessDocumentBitmap() throws IOException, InterruptedException, JSONException {
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final Bitmap testDocument = BitmapFactory.decodeStream(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder(testDocument).setDocumentType("RemittanceSlip");
+        processDocument(uploadBuilder);
+    }
+
+    public void testProcessDocumentBitmap() throws IOException, InterruptedException, JSONException {
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final Bitmap testDocument = BitmapFactory.decodeStream(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBitmap(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    public void testProcessDocumentByteArray() throws IOException, InterruptedException, JSONException {
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    public void testProcessDocumentWithCustomCache() throws IOException, JSONException, InterruptedException {
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                setCache(new NoCache()).
+                build();
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    public void testSendFeedback() throws Exception {
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        final Map<Document, Map<String, SpecificExtraction>> documentExtractions = processDocument(
+                uploadBuilder);
+        final Document document = documentExtractions.keySet().iterator().next();
+        final Map<String, SpecificExtraction> extractions = documentExtractions.values().iterator().next();
+
+        // All extractions are correct, that means we have nothing to correct and will only send positive feedback
+        // we should only send feedback for extractions we have seen and accepted
+        final Map<String, SpecificExtraction> feedback = new HashMap<>();
+        feedback.put("iban", extractions.get("iban"));
+        feedback.put("amountToPay", extractions.get("amountToPay"));
+        feedback.put("bic", extractions.get("bic"));
+        feedback.put("senderName", extractions.get("senderName"));
+
+        final Task<Document> sendFeedback = gini.getDocumentTaskManager().sendFeedbackForExtractions(document, feedback);
+        sendFeedback.waitForCompletion();
+        if (sendFeedback.isFaulted()) {
+            Log.e("TEST", Log.getStackTraceString(sendFeedback.getError()));
+        }
+        assertTrue("Sending feedback should be completed", sendFeedback.isCompleted());
+        assertFalse("Sending feedback should be successful", sendFeedback.isFaulted());
+    }
+
+    public void testDocumentUploadWorksAfterNewUserWasCreatedIfUserWasInvalid() throws IOException, JSONException, InterruptedException {
+        EncryptedCredentialsStore credentialsStore = new EncryptedCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE), getContext());
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                setCredentialsStore(credentialsStore).
+                build();
+
+        // Create invalid user credentials
+        UserCredentials invalidUserCredentials = new UserCredentials("invalid@example.com", "1234");
+        credentialsStore.storeUserCredentials(invalidUserCredentials);
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final Bitmap testDocument = BitmapFactory.decodeStream(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBitmap(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+
+        // Verify that a new user was created
+        assertNotSame(invalidUserCredentials.getUsername(), credentialsStore.getUserCredentials().getUsername());
+    }
+
+    public void testEmailDomainIsUpdatedForExistingUserIfEmailDomainWasChanged() throws IOException, JSONException, InterruptedException {
+        // Upload a document to make sure we have a valid user
+        EncryptedCredentialsStore credentialsStore = new EncryptedCredentialsStore(getContext().getSharedPreferences("GiniTests", Context.MODE_PRIVATE), getContext());
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                setCredentialsStore(credentialsStore).
+                build();
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final Bitmap testDocument = BitmapFactory.decodeStream(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBitmap(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+
+        // Create another sdk instance with a new email domain (to simulate an app update)
+        // and verify that the new email domain is used
+        String newEmailDomain = "beispiel.com";
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, newEmailDomain).
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                setCredentialsStore(credentialsStore).
+                build();
+
+        processDocument(uploadBuilder);
+
+        UserCredentials newUserCredentials = credentialsStore.getUserCredentials();
+        assertEquals(newEmailDomain, extractEmailDomain(newUserCredentials.getUsername()));
+    }
+
+    public void testPublicKeyPinningWithMatchingPublicKey() throws Exception {
+        resetTrustKit();
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setNetworkSecurityConfigResId(net.gini.android.test.R.xml.network_security_config).
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                build();
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    public void testPublicKeyPinningWithCustomCache() throws Exception {
+        resetTrustKit();
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setNetworkSecurityConfigResId(net.gini.android.test.R.xml.network_security_config).
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                setCache(new NoCache()).
+                build();
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public void testPublicKeyPinningWithWrongPublicKey() throws Exception {
+        resetTrustKit();
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setNetworkSecurityConfigResId(net.gini.android.test.R.xml.wrong_network_security_config).
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                build();
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        final DocumentTaskManager documentTaskManager = gini.getDocumentTaskManager();
+
+        final Task<Document> upload = uploadBuilder.upload(documentTaskManager);
+        final Task<Document> processDocument = upload.onSuccessTask(new Continuation<Document, Task<Document>>() {
+            @Override
+            public Task<Document> then(Task<Document> task) throws Exception {
+                Document document = task.getResult();
+                return documentTaskManager.pollDocument(document);
+            }
+        });
+
+        final Task<Map<String, SpecificExtraction>> retrieveExtractions = processDocument.onSuccessTask(new Continuation<Document, Task<Map<String, SpecificExtraction>>>() {
+            @Override
+            public Task<Map<String, SpecificExtraction>> then(Task<Document> task) throws Exception {
+                return documentTaskManager.getExtractions(task.getResult());
+            }
+        });
+
+        retrieveExtractions.waitForCompletion();
+        if (retrieveExtractions.isFaulted()) {
+            Log.e("TEST", Log.getStackTraceString(retrieveExtractions.getError()));
+        }
+
+        assertTrue("extractions shouldn't have succeeded", retrieveExtractions.isFaulted());
+    }
+
+    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public void testPublicKeyPinningWithMultiplePublicKeys() throws Exception {
+        resetTrustKit();
+        gini = new SdkBuilder(getContext(), clientId, clientSecret, "example.com").
+                setNetworkSecurityConfigResId(net.gini.android.test.R.xml.multiple_keys_network_security_config).
+                setApiBaseUrl(apiUriAccounting).
+                setGiniApiType(GiniApiType.ACCOUNTING).
+                setUserCenterApiBaseUrl(userCenterUri).
+                setConnectionTimeoutInMs(60000).
+                build();
+
+        final AssetManager assetManager = getContext().getResources().getAssets();
+        final InputStream testDocumentAsStream = assetManager.open("test.jpg");
+        assertNotNull("test image test.jpg could not be loaded", testDocumentAsStream);
+
+        final byte[] testDocument = TestUtils.createByteArray(testDocumentAsStream);
+        final DocumentUploadBuilder uploadBuilder = new DocumentUploadBuilder().setDocumentBytes(testDocument).setDocumentType(DocumentTaskManager.DocumentType.INVOICE);
+        processDocument(uploadBuilder);
+    }
+
+    private String extractEmailDomain(String email) {
+        String[] components = email.split("@");
+        if (components.length > 1) {
+            return components[1];
+        }
+        return "";
+    }
+
+    private Map<Document, Map<String, SpecificExtraction>> processDocument(DocumentUploadBuilder uploadBuilder) throws InterruptedException, JSONException {
+        final DocumentTaskManager documentTaskManager = gini.getDocumentTaskManager();
+
+        final Task<Document> upload = uploadBuilder.upload(documentTaskManager);
+        final Task<Document> processDocument = upload.onSuccessTask(new Continuation<Document, Task<Document>>() {
+            @Override
+            public Task<Document> then(Task<Document> task) throws Exception {
+                Document document = task.getResult();
+                return documentTaskManager.pollDocument(document);
+            }
+        });
+
+        final Task<Map<String, SpecificExtraction>> retrieveExtractions = processDocument.onSuccessTask(new Continuation<Document, Task<Map<String, SpecificExtraction>>>() {
+            @Override
+            public Task<Map<String, SpecificExtraction>> then(Task<Document> task) throws Exception {
+                return documentTaskManager.getExtractions(task.getResult());
+            }
+        });
+
+        retrieveExtractions.waitForCompletion();
+        if (retrieveExtractions.isFaulted()) {
+            Log.e("TEST", Log.getStackTraceString(retrieveExtractions.getError()));
+        }
+
+        assertFalse("extractions should have succeeded", retrieveExtractions.isFaulted());
+
+        final Map<String, SpecificExtraction> extractions = retrieveExtractions.getResult();
+
+        assertEquals("IBAN should be found", "DE78370501980020008850", extractions.get("iban").getValue());
+        assertEquals("Amount to pay should be found", "1.00:EUR", extractions.get("amountToPay").getValue());
+        assertEquals("BIC should be found", "COLSDE33", extractions.get("bic").getValue());
+        assertEquals("Payee should be found", "Uno Flüchtlingshilfe", extractions.get("senderName").getValue());
+
+        return Collections.singletonMap(upload.getResult(), extractions);
+    }
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/UserCenterAPICommunicatorTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/UserCenterAPICommunicatorTest.java
@@ -12,6 +12,7 @@ import com.android.volley.AuthFailureError;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 
+import net.gini.android.GiniApiType;
 import net.gini.android.requests.DefaultRetryPolicyFactory;
 import net.gini.android.requests.RetryPolicyFactory;
 
@@ -37,7 +38,7 @@ public class UserCenterAPICommunicatorTest extends InstrumentationTestCase {
         System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         retryPolicyFactory = new DefaultRetryPolicyFactory();
         mRequestQueue = Mockito.mock(RequestQueue.class);
-        apiManager = new UserCenterAPICommunicator(mRequestQueue, "https://user.gini.net/", "foobar", "1234",
+        apiManager = new UserCenterAPICommunicator(mRequestQueue, "https://user.gini.net/", GiniApiType.DEFAULT, "foobar", "1234",
                 retryPolicyFactory);
     }
 
@@ -119,7 +120,7 @@ public class UserCenterAPICommunicatorTest extends InstrumentationTestCase {
 
     public void testGetUserIdExtractsUserIdFromResponse() throws InterruptedException {
         final String userId = "JohnDoe";
-        apiManager = new UserCenterAPICommunicator(mRequestQueue, "https://user.gini.net/", "foobar", "1234",
+        apiManager = new UserCenterAPICommunicator(mRequestQueue, "https://user.gini.net/", GiniApiType.DEFAULT, "foobar", "1234",
                 retryPolicyFactory) {
             @Override
             Task<JSONObject> getGiniApiSessionTokenInfo(Session giniApiSession) {

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/requests/BearerJsonObjectRequestTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/requests/BearerJsonObjectRequestTest.java
@@ -7,6 +7,7 @@ import com.android.volley.RetryPolicy;
 
 import junit.framework.TestCase;
 
+import net.gini.android.GiniApiType;
 import net.gini.android.MediaTypes;
 import net.gini.android.authorization.Session;
 
@@ -27,7 +28,8 @@ public class BearerJsonObjectRequestTest extends TestCase {
 
     public void testAcceptHeader() throws AuthFailureError {
         Session session = new Session("1234-5678-9012", new Date());
-        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com", null, session, null, null, retryPolicy);
+        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com",
+                null, session, GiniApiType.DEFAULT, null, null, retryPolicy);
 
         Map<String, String> headers = request.getHeaders();
         assertEquals("application/json, application/vnd.gini.v2+json", headers.get("Accept"));
@@ -37,7 +39,8 @@ public class BearerJsonObjectRequestTest extends TestCase {
         Session session = new Session("1234-5678-9012", new Date());
         JSONObject payload = new JSONObject();
         payload.put("foo", "bar");
-        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com", payload, session, null, null, retryPolicy);
+        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com",
+                payload, session, GiniApiType.DEFAULT, null, null, retryPolicy);
 
         assertEquals("application/json; charset=utf-8", request.getBodyContentType());
     }
@@ -46,7 +49,8 @@ public class BearerJsonObjectRequestTest extends TestCase {
         Session session = new Session("1234-5678-9012", new Date());
         JSONObject payload = new JSONObject();
         payload.put("foo", "bar");
-        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com", payload, session, null, null, retryPolicy, MediaTypes.GINI_JSON_V2);
+        BearerJsonObjectRequest request = new BearerJsonObjectRequest(Request.Method.GET, "https://example.com", payload, session,
+                GiniApiType.DEFAULT,null, null, retryPolicy, MediaTypes.GINI_JSON_V2);
 
         assertEquals(MediaTypes.GINI_JSON_V2, request.getBodyContentType());
     }

--- a/ginisdk/src/androidTest/res/xml/network_security_config.xml
+++ b/ginisdk/src/androidTest/res/xml/network_security_config.xml
@@ -15,6 +15,12 @@
             <trustkit-config
                 disableDefaultReportUri="true"
                 enforcePinning="true" />
+            <domain includeSubdomains="false">accounting-api.gini.net</domain>
+        </domain-config>
+        <domain-config>
+            <trustkit-config
+                disableDefaultReportUri="true"
+                enforcePinning="true" />
             <domain includeSubdomains="false">user.gini.net</domain>
         </domain-config>
     </domain-config>

--- a/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
@@ -39,6 +39,7 @@ import bolts.Task;
  */
 public class DocumentTaskManager {
 
+    private final GiniApiType mGiniApiType;
     private Map<Document, Boolean> mDocumentPollingsInProgress = new ConcurrentHashMap<>();
 
     /**
@@ -83,9 +84,11 @@ public class DocumentTaskManager {
      */
     private final SessionManager mSessionManager;
 
-    public DocumentTaskManager(final ApiCommunicator apiCommunicator, final SessionManager sessionManager) {
+    public DocumentTaskManager(final ApiCommunicator apiCommunicator, final SessionManager sessionManager,
+            final GiniApiType giniApiType) {
         mApiCommunicator = checkNotNull(apiCommunicator);
         mSessionManager = checkNotNull(sessionManager);
+        mGiniApiType = checkNotNull(giniApiType);
     }
 
     /**
@@ -199,6 +202,9 @@ public class DocumentTaskManager {
 
     private Task<Document> createPartialDocumentInternal(@NonNull final byte[] document, @NonNull final String contentType,
             @Nullable final String filename, @Nullable final DocumentType documentType, @Nullable final DocumentMetadata documentMetadata) {
+        if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
+            throw new IllegalStateException("Partial documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+        }
         return createDocumentInternal(new Continuation<Session, Task<Uri>>() {
             @Override
             public Task<Uri> then(Task<Session> sessionTask) throws Exception {
@@ -208,7 +214,7 @@ public class DocumentTaskManager {
                 }
                 final Session session = sessionTask.getResult();
                 final String partialDocumentMediaType = MediaTypes
-                        .forPartialDocument(checkNotNull(contentType));
+                        .forPartialDocument(mGiniApiType.getGiniPartialMediaType(), checkNotNull(contentType));
                 return mApiCommunicator
                         .uploadDocument(document, partialDocumentMediaType, filename, apiDoctypeHint, session, documentMetadata);
             }
@@ -225,6 +231,9 @@ public class DocumentTaskManager {
      * @return A Task which will resolve to the Document instance of the freshly created document.
      */
     public Task<Document> createCompositeDocument(@NonNull final List<Document> documents, @Nullable final DocumentType documentType) {
+        if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
+            throw new IllegalStateException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+        }
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override
             public Task<Uri> then(Task<Session> sessionTask) throws Exception {
@@ -235,7 +244,7 @@ public class DocumentTaskManager {
                 final Session session = sessionTask.getResult();
                 final byte[] compositeJson = createCompositeJson(documents);
                 return mApiCommunicator
-                        .uploadDocument(compositeJson, MediaTypes.GINI_DOCUMENT_JSON_V2, null, apiDoctypeHint, session, null);
+                        .uploadDocument(compositeJson, mGiniApiType.getGiniCompositeJsonMediaType(), null, apiDoctypeHint, session, null);
             }
         }, Task.BACKGROUND_EXECUTOR).onSuccessTask(new Continuation<Uri, Task<Document>>() {
             @Override
@@ -257,6 +266,9 @@ public class DocumentTaskManager {
      * @return A Task which will resolve to the Document instance of the freshly created document.
      */
     public Task<Document> createCompositeDocument(@NonNull final LinkedHashMap<Document, Integer> documentRotationMap, @Nullable final DocumentType documentType) {
+        if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
+            throw new IllegalStateException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+        }
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override
             public Task<Uri> then(Task<Session> sessionTask) throws Exception {
@@ -267,7 +279,7 @@ public class DocumentTaskManager {
                 final Session session = sessionTask.getResult();
                 final byte[] compositeJson = createCompositeJson(documentRotationMap);
                 return mApiCommunicator
-                        .uploadDocument(compositeJson, MediaTypes.GINI_DOCUMENT_JSON_V2, null, apiDoctypeHint, session, null);
+                        .uploadDocument(compositeJson, mGiniApiType.getGiniCompositeJsonMediaType(), null, apiDoctypeHint, session, null);
             }
         }, Task.BACKGROUND_EXECUTOR).onSuccessTask(new Continuation<Uri, Task<Document>>() {
             @Override
@@ -314,7 +326,7 @@ public class DocumentTaskManager {
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * <b>Important:</b> If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
@@ -337,7 +349,7 @@ public class DocumentTaskManager {
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * <b>Important:</b> If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
@@ -387,11 +399,13 @@ public class DocumentTaskManager {
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * @deprecated If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
+     * <p>
+     * If using the accounting Gini API, then use {@link #createDocument(byte[], String, DocumentType)}.
      */
     @Deprecated
     public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
@@ -407,17 +421,19 @@ public class DocumentTaskManager {
      * @param documentType      Optional a document type hint. See the documentation for the document type hints for
      *                          possible values.
      * @param compressionRate   Optional the compression rate of the created JPEG representation of the document.
- *                              Between 0 and 90.
+     *                          Between 0 and 90.
      * @param documentMetadata  Additional information related to the document (e.g. the branch id
      *                          to which the client app belongs)
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * @deprecated If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType, DocumentMetadata)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
+     * <p>
+     * If using the accounting Gini API, then use {@link #createDocument(byte[], String, DocumentType, DocumentMetadata)}.
      */
     @Deprecated
     public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
@@ -434,11 +450,13 @@ public class DocumentTaskManager {
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * @deprecated If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
+     * <p>
+     * If using the accounting Gini API, then use {@link #createDocument(byte[], String, DocumentType)}.
      */
     public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
                                           @Nullable final DocumentType documentType) {
@@ -460,11 +478,13 @@ public class DocumentTaskManager {
      *
      * @return A Task which will resolve to the Document instance of the freshly created document.
      *
-     * @deprecated Use {@link #createPartialDocument(byte[], String, String, DocumentType)} to upload the
+     * @deprecated If using the default Gini API, then use {@link #createPartialDocument(byte[], String, String, DocumentType, DocumentMetadata)} to upload the
      * document and then call {@link #createCompositeDocument(LinkedHashMap, DocumentType)}
      * (or {@link #createCompositeDocument(List, DocumentType)}) to finish document creation. The
      * returned composite document can be used to poll the processing state, to retrieve extractions
      * and to send feedback.
+     * <p>
+     * If using the accounting Gini API, then use {@link #createDocument(byte[], String, DocumentType, DocumentMetadata)}.
      */
     public Task<Document> createDocument(@NonNull final Bitmap document, @Nullable final String filename,
             @Nullable final DocumentType documentType, @NonNull final DocumentMetadata documentMetadata) {

--- a/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
@@ -203,7 +203,7 @@ public class DocumentTaskManager {
     private Task<Document> createPartialDocumentInternal(@NonNull final byte[] document, @NonNull final String contentType,
             @Nullable final String filename, @Nullable final DocumentType documentType, @Nullable final DocumentMetadata documentMetadata) {
         if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
-            throw new IllegalStateException("Partial documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+            throw new UnsupportedOperationException("Partial documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
         }
         return createDocumentInternal(new Continuation<Session, Task<Uri>>() {
             @Override
@@ -232,7 +232,7 @@ public class DocumentTaskManager {
      */
     public Task<Document> createCompositeDocument(@NonNull final List<Document> documents, @Nullable final DocumentType documentType) {
         if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
-            throw new IllegalStateException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+            throw new UnsupportedOperationException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
         }
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override
@@ -267,7 +267,7 @@ public class DocumentTaskManager {
      */
     public Task<Document> createCompositeDocument(@NonNull final LinkedHashMap<Document, Integer> documentRotationMap, @Nullable final DocumentType documentType) {
         if (!mGiniApiType.getGiniJsonMediaType().equals(MediaTypes.GINI_JSON_V2)) {
-            throw new IllegalStateException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
+            throw new UnsupportedOperationException("Composite documents may be used only with the default Gini API. Use GiniApiType.DEFAULT.");
         }
         return mSessionManager.getSession().onSuccessTask(new Continuation<Session, Task<Uri>>() {
             @Override

--- a/ginisdk/src/main/java/net/gini/android/GiniApiType.java
+++ b/ginisdk/src/main/java/net/gini/android/GiniApiType.java
@@ -1,0 +1,55 @@
+package net.gini.android;
+
+import static net.gini.android.MediaTypes.*;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Created by Alpar Szotyori on 14.01.2019.
+ *
+ * Copyright (c) 2019 Gini GmbH.
+ */
+
+/**
+ * The current supported APIs.
+ */
+public enum GiniApiType {
+    DEFAULT("https://api.gini.net/",
+            GINI_JSON_V2,
+            GINI_PARTIAL,
+            GINI_DOCUMENT_JSON_V2),
+    ACCOUNTING("https://accounting-api.gini.net/",
+            GINI_JSON_V1,
+            "","");
+
+    private final String mBaseUrl;
+    private final String mGiniJsonMediaType;
+    private final String mGiniPartialMediaType;
+    private final String mGiniCompositeJsonMediaType;
+
+    GiniApiType(@NonNull final String baseUrl,
+            @NonNull final String giniJsonMediaType,
+            @NonNull final String giniPartialMediaType,
+            @NonNull final String giniCompositeJsonMediaType) {
+        mBaseUrl = baseUrl;
+        mGiniJsonMediaType = giniJsonMediaType;
+        mGiniPartialMediaType = giniPartialMediaType;
+        mGiniCompositeJsonMediaType = giniCompositeJsonMediaType;
+    }
+
+    public String getBaseUrl() {
+        return mBaseUrl;
+    }
+
+    public String getGiniJsonMediaType() {
+        return mGiniJsonMediaType;
+    }
+
+    public String getGiniPartialMediaType() {
+        return mGiniPartialMediaType;
+    }
+
+    public String getGiniCompositeJsonMediaType() {
+        return mGiniCompositeJsonMediaType;
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/MediaTypes.java
+++ b/ginisdk/src/main/java/net/gini/android/MediaTypes.java
@@ -15,9 +15,9 @@ public class MediaTypes {
     public static final String GINI_PARTIAL = "application/vnd.gini.v2.partial";
     public static final String GINI_DOCUMENT_JSON_V2 = "application/vnd.gini.v2.composite+json";
 
-    public static String forPartialDocument(@NonNull final String mediaType) {
+    public static String forPartialDocument(@NonNull final String partialMediaType, @NonNull final String mediaType) {
         final String subtype = getSubtype(mediaType);
-        return GINI_PARTIAL + "+" + subtype;
+        return partialMediaType + "+" + subtype;
     }
 
     @Nullable

--- a/ginisdk/src/main/java/net/gini/android/authorization/UserCenterAPICommunicator.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/UserCenterAPICommunicator.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
 
+import net.gini.android.GiniApiType;
 import net.gini.android.RequestTaskCompletionSource;
 import net.gini.android.authorization.requests.BearerJsonObjectRequest;
 import net.gini.android.authorization.requests.TokenRequest;
@@ -35,12 +36,15 @@ public class UserCenterAPICommunicator {
     final private String mClientId;
     final private String mClientSecret;
     final private RetryPolicyFactory mRetryPolicyFactory;
+    private final GiniApiType mGiniApiType;
 
     public UserCenterAPICommunicator(final RequestQueue requestQueue, final String baseUrl,
+                                     final GiniApiType giniApiType,
                                      final String clientId, final String clientSecret,
                                      final RetryPolicyFactory retryPolicyFactory) {
         mRequestQueue = requestQueue;
         mBaseUrl = baseUrl;
+        mGiniApiType = giniApiType;
         mClientId = clientId;
         mClientSecret = clientSecret;
         this.mRetryPolicyFactory = retryPolicyFactory;
@@ -122,7 +126,7 @@ public class UserCenterAPICommunicator {
         final RequestTaskCompletionSource<JSONObject> completionSource =
                 RequestTaskCompletionSource.newCompletionSource();
         final BearerJsonObjectRequest request =
-                new BearerJsonObjectRequest(GET, userUri.toString(), null, userCenterApiSession, completionSource,
+                new BearerJsonObjectRequest(GET, userUri.toString(), null, userCenterApiSession, mGiniApiType, completionSource,
                         completionSource, mRetryPolicyFactory.newRetryPolicy());
 
         mRequestQueue.add(request);
@@ -194,8 +198,8 @@ public class UserCenterAPICommunicator {
             put("email", newEmail);
         }};
         final BearerJsonObjectRequest request =
-                new BearerJsonObjectRequest(PUT, url, data, userCenterApiSession, completionSource,
-                        completionSource, mRetryPolicyFactory.newRetryPolicy());
+                new BearerJsonObjectRequest(PUT, url, data, userCenterApiSession, mGiniApiType,
+                        completionSource, completionSource, mRetryPolicyFactory.newRetryPolicy());
         mRequestQueue.add(request);
 
         return completionSource.getTask();

--- a/ginisdk/src/main/java/net/gini/android/authorization/requests/BearerJsonObjectRequest.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/requests/BearerJsonObjectRequest.java
@@ -1,5 +1,6 @@
 package net.gini.android.authorization.requests;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.android.volley.AuthFailureError;
@@ -10,6 +11,7 @@ import com.android.volley.RetryPolicy;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.android.volley.toolbox.JsonObjectRequest;
 
+import net.gini.android.GiniApiType;
 import net.gini.android.MediaTypes;
 import net.gini.android.Utils;
 import net.gini.android.authorization.Session;
@@ -24,16 +26,22 @@ import java.util.Map;
 public class BearerJsonObjectRequest extends JsonObjectRequest {
     final private Session mSession;
     final private String contentType;
+    private final GiniApiType mGiniApiType;
 
-    public BearerJsonObjectRequest(int method, String url, JSONObject jsonRequest, Session session, Response.Listener<JSONObject> listener, Response.ErrorListener errorListener, RetryPolicy retryPolicy) {
-        this(method, url, jsonRequest, session, listener, errorListener, retryPolicy, null);
+    public BearerJsonObjectRequest(int method, String url, JSONObject jsonRequest, Session session, @NonNull final GiniApiType giniApiType,
+            Response.Listener<JSONObject> listener, Response.ErrorListener errorListener, RetryPolicy retryPolicy) {
+        this(method, url, jsonRequest, session, giniApiType, listener, errorListener, retryPolicy, null);
     }
 
-    public BearerJsonObjectRequest(int method, String url, JSONObject jsonRequest, Session session, Response.Listener<JSONObject> listener, Response.ErrorListener errorListener, RetryPolicy retryPolicy, @Nullable String contentType) {
+    public BearerJsonObjectRequest(int method, String url, JSONObject jsonRequest,
+            Session session, @NonNull final GiniApiType giniApiType,
+            Response.Listener<JSONObject> listener, Response.ErrorListener errorListener,
+            RetryPolicy retryPolicy, @Nullable String contentType) {
         super(method, url, jsonRequest, listener, errorListener);
         setRetryPolicy(retryPolicy);
         mSession = session;
         this.contentType = contentType == null ? super.getBodyContentType() : contentType;
+        mGiniApiType = giniApiType;
     }
 
     @Override
@@ -44,7 +52,7 @@ public class BearerJsonObjectRequest extends JsonObjectRequest {
     @Override
     public Map<String, String> getHeaders() throws AuthFailureError {
         HashMap<String, String> headers = new HashMap<String, String>();
-        headers.put("Accept", String.format("%s, %s", MediaTypes.APPLICATION_JSON, MediaTypes.GINI_JSON_V2));
+        headers.put("Accept", String.format("%s, %s", MediaTypes.APPLICATION_JSON, mGiniApiType.getGiniJsonMediaType()));
         headers.put("Authorization", "BEARER " + mSession.getAccessToken());
         return headers;
     }

--- a/ginisdk/src/main/java/net/gini/android/requests/BearerUploadRequest.java
+++ b/ginisdk/src/main/java/net/gini/android/requests/BearerUploadRequest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.android.volley.Response;
 import com.android.volley.RetryPolicy;
 
+import net.gini.android.GiniApiType;
 import net.gini.android.MediaTypes;
 import net.gini.android.authorization.Session;
 
@@ -17,18 +18,20 @@ public class BearerUploadRequest extends BearerLocationRequest{
     private final String mContentType;
     private final String mAccessToken;
     private final Map<String, String> mHeaders;
+    private final GiniApiType mGiniApiType;
 
     public BearerUploadRequest(int method, String url, byte[] uploadData, String contentType,
             final Session session,
+            final GiniApiType giniApiType,
             Response.Listener<Uri> listener,
             Response.ErrorListener errorListener,
             RetryPolicy retryPolicy,
             final Map<String, String> headers) {
         super(method, url, null, session, listener, errorListener, retryPolicy);
-
         mUploadData = uploadData;
         mContentType = contentType;
         mAccessToken = session.getAccessToken();
+        mGiniApiType = giniApiType;
         mHeaders = headers;
     }
 
@@ -40,7 +43,7 @@ public class BearerUploadRequest extends BearerLocationRequest{
     @Override
     public Map<String, String> getHeaders() {
         HashMap<String, String> headers = new HashMap<>(mHeaders);
-        headers.put("Accept", String.format("%s, %s", MediaTypes.APPLICATION_JSON, MediaTypes.GINI_JSON_V2));
+        headers.put("Accept", String.format("%s, %s", MediaTypes.APPLICATION_JSON, mGiniApiType.getGiniJsonMediaType()));
         headers.put("Authorization", "BEARER " + mAccessToken);
         return headers;
     }


### PR DESCRIPTION
Added support for the accounting api in a similar way as it has been done for the iOS version.

Using the `GiniApiType.ACCOUNTING` the SDK will communicate with the accounting api. This means that the partial and composite methods in the `DocumentTaskManager` won't work (throws UnsupportedOperationException). Otherwise everything works as before.

If not setting `GiniApiType.ACCOUNTING` the SDK behaves as before. No breaking changes were introduced.