### PR TITLE
Line item extractions

### DIFF
--- a/ginisdk/src/androidTest/assets/extractions.json
+++ b/ginisdk/src/androidTest/assets/extractions.json
@@ -1,53 +1,219 @@
- {
-    "extractions": {
-        "amountToPay": {
-            "box": {
-                "height": 9.0,
-                "left": 516.0,
-                "page": 1,
-                "top": 588.0,
-                "width": 42.0
-            },
-            "entity": "amount",
-            "value": "24.99:EUR",
-            "candidates": "amounts"
+{
+  "extractions": {
+    "amountToPay": {
+      "box": {
+        "height": 9.0,
+        "left": 516.0,
+        "page": 1,
+        "top": 588.0,
+        "width": 42.0
+      },
+      "entity": "amount",
+      "value": "24.99:EUR",
+      "candidates": "amounts"
+    },
+    "recipient": {
+      "entity": "recipient",
+      "value": "Foo Bar Beispielstraße 23 80331 München",
+      "box": {
+        "page": 1,
+        "left": 60.0,
+        "top": 169.0,
+        "width": 67.0,
+        "height": 34.0
+      }
+    },
+    "lineItems": [
+      {
+        "artNumber": {
+          "box": {
+            "height": 9.0,
+            "left": 82.0,
+            "page": 1,
+            "top": 347.11,
+            "width": 103.72999999999999
+          },
+          "entity": "idnumber",
+          "value": "H0422S039-M11000L000"
         },
-        "recipient": {
-            "entity": "recipient",
-            "value": "Foo Bar Beispielstraße 23 80331 München",
-            "box": {
-                "page": 1,
-                "left": 60.0,
-                "top": 169.0,
-                "width": 67.0,
-                "height": 34.0
-            }
+        "description": {
+          "box": {
+            "height": 21.97999999999996,
+            "left": 200.0,
+            "page": 1,
+            "top": 347.11,
+            "width": 110.5
+          },
+          "entity": "text",
+          "value": "CORE ICON - Sweatjacke - emerald"
+        },
+        "grossPrice": {
+          "box": {
+            "height": 9.0,
+            "left": 418.48,
+            "page": 1,
+            "top": 347.11,
+            "width": 22.519999999999982
+          },
+          "entity": "amount",
+          "value": "39.99:EUR"
+        },
+        "quantity": {
+          "box": {
+            "height": 9.0,
+            "left": 72.0,
+            "page": 1,
+            "top": 347.11,
+            "width": 5.0
+          },
+          "entity": "number",
+          "value": "1"
         }
       },
-      "candidates": {
-        "amounts": [
-          {
-              "box": {
-                  "height": 9.0,
-                  "left": 516.0,
-                  "page": 1,
-                  "top": 588.0,
-                  "width": 42.0
-              },
-              "entity": "amount",
-              "value": "24.99:EUR"
+      {
+        "artNumber": {
+          "box": {
+            "height": 9.0,
+            "left": 82.0,
+            "page": 1,
+            "top": 377.11,
+            "width": 103.57
           },
-          {
-              "box": {
-                  "height": 9.0,
-                  "left": 241.0,
-                  "page": 1,
-                  "top": 588.0,
-                  "width": 42.0
-              },
-              "entity": "amount",
-              "value": "21.0:EUR"
-          }
-        ]
+          "entity": "idnumber",
+          "value": "YO122Q047-E11000L000"
+        },
+        "description": {
+          "box": {
+            "height": 9.0,
+            "left": 200.0,
+            "page": 1,
+            "top": 377.11,
+            "width": 88.82
+          },
+          "entity": "text",
+          "value": "Strickpullover - yellow"
+        },
+        "grossPrice": {
+          "box": {
+            "height": 9.0,
+            "left": 418.48,
+            "page": 1,
+            "top": 377.11,
+            "width": 22.519999999999982
+          },
+          "entity": "amount",
+          "value": "34.99:EUR"
+        },
+        "quantity": {
+          "box": {
+            "height": 9.0,
+            "left": 72.0,
+            "page": 1,
+            "top": 377.11,
+            "width": 5.0
+          },
+          "entity": "number",
+          "value": "1"
+        }
+      },
+      {
+        "artNumber": {
+          "box": {
+            "height": 9.0,
+            "left": 82.0,
+            "page": 1,
+            "top": 394.11,
+            "width": 105.24000000000001
+          },
+          "entity": "idnumber",
+          "value": "JAM22Q01E-K11000L000"
+        },
+        "description": {
+          "box": {
+            "height": 21.97999999999996,
+            "left": 200.0,
+            "page": 1,
+            "top": 394.11,
+            "width": 119.83999999999997
+          },
+          "entity": "text",
+          "value": "JPRDEEP CREW NECK - Strickpullover - vintage indigo"
+        },
+        "grossPrice": {
+          "box": {
+            "height": 9.0,
+            "left": 418.48,
+            "page": 1,
+            "top": 394.11,
+            "width": 22.519999999999982
+          },
+          "entity": "amount",
+          "value": "49.99:EUR"
+        },
+        "quantity": {
+          "box": {
+            "height": 9.0,
+            "left": 72.0,
+            "page": 1,
+            "top": 394.11,
+            "width": 5.0
+          },
+          "entity": "number",
+          "value": "1"
+        }
       }
+    ],
+    "paymentRecipient": {
+      "box": {
+        "height": 8.159999999999968,
+        "left": 480.96,
+        "page": 1,
+        "top": 583.92,
+        "width": 29.75999999999999
+      },
+      "entity": "companyname",
+      "value": "Charge"
+    },
+    "paymentReference": {
+      "entity": "reference",
+      "value": "ReNr INV07604869"
+    },
+    "senderName": {
+      "box": {
+        "height": 8.159999999999968,
+        "left": 480.96,
+        "page": 1,
+        "top": 583.92,
+        "width": 29.75999999999999
+      },
+      "entity": "companyname",
+      "value": "Charge"
     }
+  },
+  "candidates": {
+    "amounts": [
+      {
+        "box": {
+          "height": 9.0,
+          "left": 516.0,
+          "page": 1,
+          "top": 588.0,
+          "width": 42.0
+        },
+        "entity": "amount",
+        "value": "24.99:EUR"
+      },
+      {
+        "box": {
+          "height": 9.0,
+          "left": 241.0,
+          "page": 1,
+          "top": 588.0,
+          "width": 42.0
+        },
+        "entity": "amount",
+        "value": "21.0:EUR"
+      }
+    ]
+  }
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -795,12 +796,24 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
         final List<SpecificExtraction> lineItemExtractionColumns = lineItemExtractions.get(0).getSpecificExtractions();
         assertEquals(4, lineItemExtractionColumns.size());
 
-        assertEquals("artNumber", lineItemExtractionColumns.get(0).getName());
-        assertEquals("description", lineItemExtractionColumns.get(1).getName());
-        assertEquals("grossPrice", lineItemExtractionColumns.get(2).getName());
-        assertEquals("quantity", lineItemExtractionColumns.get(3).getName());
+        SpecificExtraction artNumberColumn = null;
 
-        assertEquals("H0422S039-M11000L000", lineItemExtractionColumns.get(0).getValue());
-        assertEquals("idnumber", lineItemExtractionColumns.get(0).getEntity());
+        final List<String> columnNames = Arrays.asList("artNumber", "description", "grossPrice", "quantity");
+        for (final String columnName : columnNames) {
+            boolean found = false;
+            for (final SpecificExtraction lineItemExtractionColumn : lineItemExtractionColumns) {
+                if (lineItemExtractionColumn.getName().equals(columnName)) {
+                    if (columnName.equals("artNumber")) {
+                        artNumberColumn = lineItemExtractionColumn;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found);
+        }
+
+        assertEquals("H0422S039-M11000L000", artNumberColumn.getValue());
+        assertEquals("idnumber", artNumberColumn.getEntity());
     }
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkIntegrationTest.java
@@ -469,14 +469,16 @@ public class SdkIntegrationTest extends AndroidTestCase {
         final String amountToPay = extractions.get("amountToPay").getValue();
         assertTrue("Amount to pay should be found: "
                         + "expected one of <[145.00:EUR, 77.00:EUR, 588.60:EUR, 700.43:EUR]> but was:<["
-                        + amountToPay +"]>",
+                        + amountToPay + "]>",
                 amountToPay.equals("145.00:EUR")
                         || amountToPay.equals("77.00:EUR")
                         || amountToPay.equals("588.60:EUR")
                         || amountToPay.equals("700.43:EUR"));
         assertEquals("BIC should be found", "WELADED1MIN", extractions.get("bic").getValue());
         assertTrue("Payement recipient should be found", extractions.get("paymentRecipient").getValue().startsWith("Mindener Stadtwerke"));
-        assertEquals("Payment reference should be found", "ReNr TST-00019, KdNr 765432", extractions.get("paymentReference").getValue());
+        assertEquals("Payment reference should be found",
+                "ReNr TST-00019, KdNr 765432, Fälligkeitsdatum 29.01.14, Rechnungsdatum 14.01.14, Verbrauchsstellennummer 5959595",
+                extractions.get("paymentReference").getValue());
 
         // all extractions are correct, that means we have nothing to correct and will only send positive feedback
         // we should only send feedback for extractions we have seen and accepted

--- a/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
@@ -7,12 +7,14 @@ import android.os.Parcelable;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SpecificExtraction extends Extraction {
 
     private final String mName;
     private final List<Extraction> mCandidates;
+    private final List<SpecificExtraction> mSpecificExtractions;
 
     /**
      * Value object for a specific extraction from the Gini API.
@@ -26,12 +28,29 @@ public class SpecificExtraction extends Extraction {
      *                   are of the same entity as the found extraction.
      */
     public SpecificExtraction(final String name, final String value, final String entity,
-                              @Nullable final Box box, final
-    List<Extraction> candidates) {
+                              @Nullable final Box box, final List<Extraction> candidates) {
+        this(name, value, entity, box, candidates, Collections.<SpecificExtraction>emptyList());
+    }
+
+    /**
+     * Value object for a specific extraction from the Gini API.
+     *
+     * @param name                  The specific extraction's name, e.g. "amountToPay".
+     * @param value                 The extraction's value. Changing this value marks the extraction as dirty.
+     * @param entity                The extraction's entity.
+     * @param box                   Optional the box where the extraction is found. Only available on some
+     *                              extractions.
+     * @param candidates            A list containing other candidates for this specific extraction. Candidates
+     *                              are of the same entity as the found extraction.
+     * @param specificExtractions   A list of other specific extractions which are part of this one.
+     */
+    public SpecificExtraction(final String name, final String value, final String entity,
+            @Nullable final Box box, final List<Extraction> candidates, final List<SpecificExtraction> specificExtractions) {
         super(value, entity, box);
 
         mName = checkNotNull(name);
         mCandidates = checkNotNull(candidates);
+        mSpecificExtractions = specificExtractions;
     }
 
     /**
@@ -43,6 +62,9 @@ public class SpecificExtraction extends Extraction {
         final List<Extraction> candidates = new ArrayList<Extraction>();
         in.readTypedList(candidates, Extraction.CREATOR);
         mCandidates = candidates;
+        final List<SpecificExtraction> specificExtractions = new ArrayList<>();
+        in.readTypedList(specificExtractions, SpecificExtraction.CREATOR);
+        mSpecificExtractions = specificExtractions;
     }
 
     public String getName() {
@@ -51,6 +73,10 @@ public class SpecificExtraction extends Extraction {
 
     public List<Extraction> getCandidate() {
         return mCandidates;
+    }
+
+    public List<SpecificExtraction> getSpecificExtractions() {
+        return mSpecificExtractions;
     }
 
     @Override
@@ -63,6 +89,7 @@ public class SpecificExtraction extends Extraction {
         super.writeToParcel(dest, flags);
         dest.writeString(mName);
         dest.writeTypedList(mCandidates);
+        dest.writeTypedList(mSpecificExtractions);
     }
 
     public static final Parcelable.Creator<SpecificExtraction> CREATOR =


### PR DESCRIPTION
Line items are parsed according to the following example:
```
{
    "extractions": {
        "lineItems": [
            {
                "artNumber": {
                    "box": {
                        "height": 9.0,
                        "left": 82.0,
                        "page": 1,
                        "top": 347.11,
                        "width": 103.72999999999999
                    },
                    "entity": "idnumber",
                    "value": "H0422S039-M11000L000"
                },
                "description": {
                    "box": {
                        "height": 21.97999999999996,
                        "left": 200.0,
                        "page": 1,
                        "top": 347.11,
                        "width": 110.5
                    },
                    "entity": "text",
                    "value": "CORE ICON - Sweatjacke - emerald"
                },
                "grossPrice": {
                    "box": {
                        "height": 9.0,
                        "left": 418.48,
                        "page": 1,
                        "top": 347.11,
                        "width": 22.519999999999982
                    },
                    "entity": "amount",
                    "value": "39.99:EUR"
                },
                "quantity": {
                    "box": {
                        "height": 9.0,
                        "left": 72.0,
                        "page": 1,
                        "top": 347.11,
                        "width": 5.0
                    },
                    "entity": "number",
                    "value": "1"
                }
            }
        ]
    }
}
```

Did not introduce a new model class for line items. I extended `SpecificExtraction` with a list of `SpecificExtraction`s to keep the public API stable.

To get the line items one has to know the name of the line items extractions (above it's `lineItems`) and then iterate over `SpecificExtraction.getSpecificExtractions()` to get each line item. For each line item one has to again call `getSpecificExtractions()` to get the extraction for each of its columns.