### PR TITLE
Using compound extractions

### DIFF
--- a/ginisdk/src/androidTest/assets/extractions.json
+++ b/ginisdk/src/androidTest/assets/extractions.json
@@ -23,6 +23,34 @@
         "height": 34.0
       }
     },
+    "paymentRecipient": {
+      "box": {
+        "height": 8.159999999999968,
+        "left": 480.96,
+        "page": 1,
+        "top": 583.92,
+        "width": 29.75999999999999
+      },
+      "entity": "companyname",
+      "value": "Charge"
+    },
+    "paymentReference": {
+      "entity": "reference",
+      "value": "ReNr INV07604869"
+    },
+    "senderName": {
+      "box": {
+        "height": 8.159999999999968,
+        "left": 480.96,
+        "page": 1,
+        "top": 583.92,
+        "width": 29.75999999999999
+      },
+      "entity": "companyname",
+      "value": "Charge"
+    }
+  },
+  "compoundExtractions": {
     "lineItems": [
       {
         "artNumber": {
@@ -162,33 +190,7 @@
           "value": "1"
         }
       }
-    ],
-    "paymentRecipient": {
-      "box": {
-        "height": 8.159999999999968,
-        "left": 480.96,
-        "page": 1,
-        "top": 583.92,
-        "width": 29.75999999999999
-      },
-      "entity": "companyname",
-      "value": "Charge"
-    },
-    "paymentReference": {
-      "entity": "reference",
-      "value": "ReNr INV07604869"
-    },
-    "senderName": {
-      "box": {
-        "height": 8.159999999999968,
-        "left": 480.96,
-        "page": 1,
-        "top": 583.92,
-        "width": 29.75999999999999
-      },
-      "entity": "companyname",
-      "value": "Charge"
-    }
+    ]
   },
   "candidates": {
     "amounts": [

--- a/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/DocumentTaskManagerTest.java
@@ -20,8 +20,10 @@ import net.gini.android.DocumentTaskManager.DocumentType;
 import net.gini.android.authorization.Session;
 import net.gini.android.authorization.SessionManager;
 import net.gini.android.helpers.TestUtils;
+import net.gini.android.models.CompoundExtraction;
 import net.gini.android.models.Document;
 import net.gini.android.models.Extraction;
+import net.gini.android.models.ExtractionsContainer;
 import net.gini.android.models.SpecificExtraction;
 
 import org.json.JSONException;
@@ -773,47 +775,55 @@ public class DocumentTaskManagerTest extends InstrumentationTestCase {
         assertNotNull(responseData);
     }
 
-    public void testGetExtractionsParsesLineItems() throws Exception {
+    public void testGetExtractionsParsesCompoundExtractions() throws Exception {
         when(mApiCommunicator.getExtractions(eq("1234"), any(Session.class))).thenReturn(createExtractionsJSONTask());
         Document document = new Document("1234", Document.ProcessingState.COMPLETED, "foobar", 1, new Date(),
                 Document.SourceClassification.NATIVE, Uri.parse(""), new ArrayList<Uri>(),
                 new ArrayList<Uri>());
 
-        Task<Map<String, SpecificExtraction>> extractionsTask = mDocumentTaskManager.getExtractions(document);
+        Task<ExtractionsContainer> extractionsTask = mDocumentTaskManager.getAllExtractions(document);
         extractionsTask.waitForCompletion();
         if (extractionsTask.isFaulted()) {
             throw extractionsTask.getError();
         }
-        final Map<String, SpecificExtraction> extractions = extractionsTask.getResult();
+        final ExtractionsContainer extractions = extractionsTask.getResult();
         assertNotNull(extractions);
 
-        final SpecificExtraction lineItems = extractions.get("lineItems");
+        final CompoundExtraction lineItems = extractions.getCompoundExtractions().get("lineItems");
         assertNotNull(lineItems);
 
-        final List<SpecificExtraction> lineItemExtractions = lineItems.getSpecificExtractions();
+        final List<Map<String, SpecificExtraction>> lineItemExtractions = lineItems.getSpecificExtractionMaps();
         assertEquals(3, lineItemExtractions.size());
 
-        final List<SpecificExtraction> lineItemExtractionColumns = lineItemExtractions.get(0).getSpecificExtractions();
+        final Map<String, SpecificExtraction> lineItemExtractionColumns = lineItemExtractions.get(0);
         assertEquals(4, lineItemExtractionColumns.size());
-
-        SpecificExtraction artNumberColumn = null;
 
         final List<String> columnNames = Arrays.asList("artNumber", "description", "grossPrice", "quantity");
         for (final String columnName : columnNames) {
-            boolean found = false;
-            for (final SpecificExtraction lineItemExtractionColumn : lineItemExtractionColumns) {
-                if (lineItemExtractionColumn.getName().equals(columnName)) {
-                    if (columnName.equals("artNumber")) {
-                        artNumberColumn = lineItemExtractionColumn;
-                    }
-                    found = true;
-                    break;
-                }
-            }
-            assertTrue(found);
+            assertNotNull(lineItemExtractionColumns.get(columnName));
         }
+
+        SpecificExtraction artNumberColumn = lineItemExtractionColumns.get("artNumber");
 
         assertEquals("H0422S039-M11000L000", artNumberColumn.getValue());
         assertEquals("idnumber", artNumberColumn.getEntity());
+    }
+
+    public void testGetAllExtractionsResolvesToExtractionResult() throws Exception {
+        when(mApiCommunicator.getExtractions(eq("1234"), any(Session.class))).thenReturn(createExtractionsJSONTask());
+        Document document = new Document("1234", Document.ProcessingState.COMPLETED, "foobar", 1, new Date(),
+                Document.SourceClassification.NATIVE, Uri.parse(""), new ArrayList<Uri>(),
+                new ArrayList<Uri>());
+
+        Task<ExtractionsContainer> extractionsTask = mDocumentTaskManager.getAllExtractions(document);
+        extractionsTask.waitForCompletion();
+        if (extractionsTask.isFaulted()) {
+            throw extractionsTask.getError();
+        }
+        final ExtractionsContainer extractions = extractionsTask.getResult();
+        assertNotNull(extractions);
+        final SpecificExtraction amountToPay = extractions.getSpecificExtractions().get("amountToPay");
+        assertNotNull(amountToPay);
+        assertEquals(2, amountToPay.getCandidate().size());
     }
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/models/CompoundExtractionTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/models/CompoundExtractionTest.java
@@ -1,0 +1,45 @@
+package net.gini.android.models;
+
+import static net.gini.android.helpers.ParcelHelper.doRoundTrip;
+
+import android.support.test.filters.SmallTest;
+import android.test.AndroidTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SmallTest
+public class CompoundExtractionTest extends AndroidTestCase {
+
+    public void testIsParcelable() {
+        final Box box = new Box(1, 2, 3, 4, 5);
+
+        final List<Map<String, SpecificExtraction>> rows = new ArrayList<>();
+
+        final Map<String, SpecificExtraction> firstRowColumns = new HashMap<>();
+        firstRowColumns.put("description", new SpecificExtraction("description", "CORE ICON - Sweatjacke - emerald", "text", box, Collections.<Extraction>emptyList()));
+        firstRowColumns.put("grossPrice", new SpecificExtraction("grossPrice", "39.99:EUR", "amount", box, Collections.<Extraction>emptyList()));
+        rows.add(firstRowColumns);
+
+        final Map<String, SpecificExtraction> secondRowColumns = new HashMap<>();
+        secondRowColumns.put("description", new SpecificExtraction("description", "Strickpullover - yellow", "text", box, Collections.<Extraction>emptyList()));
+        secondRowColumns.put("grossPrice", new SpecificExtraction("grossPrice", "59.99:EUR", "amount", box, Collections.<Extraction>emptyList()));
+        rows.add(secondRowColumns);
+
+        final CompoundExtraction compoundExtraction = new CompoundExtraction("lineItems", rows);
+
+        final CompoundExtraction restoredExtraction =
+                doRoundTrip(compoundExtraction, CompoundExtraction.CREATOR);
+
+        assertEquals("lineItems", restoredExtraction.getName());
+
+        assertEquals("CORE ICON - Sweatjacke - emerald", restoredExtraction.getSpecificExtractionMaps().get(0).get("description").getValue());
+        assertEquals("39.99:EUR", restoredExtraction.getSpecificExtractionMaps().get(0).get("grossPrice").getValue());
+
+        assertEquals("Strickpullover - yellow", restoredExtraction.getSpecificExtractionMaps().get(1).get("description").getValue());
+        assertEquals("59.99:EUR", restoredExtraction.getSpecificExtractionMaps().get(1).get("grossPrice").getValue());
+    }
+}

--- a/ginisdk/src/androidTest/java/net/gini/android/models/ExtractionsContainerTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/models/ExtractionsContainerTest.java
@@ -1,0 +1,46 @@
+package net.gini.android.models;
+
+import static net.gini.android.helpers.ParcelHelper.doRoundTrip;
+
+import android.support.test.filters.SmallTest;
+import android.test.AndroidTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SmallTest
+public class ExtractionsContainerTest extends AndroidTestCase {
+
+    public void testIsParcelable() {
+        final ArrayList<Extraction> candidates = new ArrayList<Extraction>();
+        candidates.add(new Extraction("0:EUR", "amount", null));
+        candidates.add(new Extraction("12.99:EUR", "amount", null));
+        final Box box = new Box(1, 2, 3, 4, 5);
+        SpecificExtraction specificExtraction =
+                new SpecificExtraction("amountToPay", "23.23:EUR", "amount", box, candidates);
+
+        final List<Map<String, SpecificExtraction>> rows = new ArrayList<>();
+        final Map<String, SpecificExtraction> row = new HashMap<>();
+        row.put("description", new SpecificExtraction("description", "CORE ICON - Sweatjacke - emerald", "text", box,
+                Collections.<Extraction>emptyList()));
+        row.put("grossPrice", new SpecificExtraction("grossPrice", "39.99:EUR", "amount", box, Collections.<Extraction>emptyList()));
+        rows.add(row);
+        final CompoundExtraction compoundExtraction = new CompoundExtraction("lineItems", rows);
+
+        final ExtractionsContainer extractions = new ExtractionsContainer(
+                Collections.singletonMap("amountToPay", specificExtraction),
+                Collections.singletonMap("lineItems", compoundExtraction)
+        );
+
+        final ExtractionsContainer restoredExtractions =
+                doRoundTrip(extractions, ExtractionsContainer.CREATOR);
+
+        assertEquals("amountToPay", restoredExtractions.getSpecificExtractions().get("amountToPay").getName());
+        assertEquals("lineItems", restoredExtractions.getCompoundExtractions().get("lineItems").getName());
+        assertEquals("CORE ICON - Sweatjacke - emerald", restoredExtractions.getCompoundExtractions().get(
+                "lineItems").getSpecificExtractionMaps().get(0).get("description").getValue());
+    }
+}

--- a/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
@@ -25,6 +25,7 @@ import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -607,7 +608,7 @@ public class DocumentTaskManager {
                                 parseSpecificExtractions(responseData.getJSONObject("extractions"), candidates);
 
                         final Map<String, CompoundExtraction> compoundExtractions =
-                                parseCompoundExtractions(responseData.getJSONObject("compoundExtractions"), candidates);
+                                parseCompoundExtractions(responseData.optJSONObject("compoundExtractions"), candidates);
 
                         return new ExtractionsContainer(specificExtractions, compoundExtractions);
                     }
@@ -643,9 +644,12 @@ public class DocumentTaskManager {
         return specificExtractions;
     }
 
-    private Map<String, CompoundExtraction> parseCompoundExtractions(@NonNull final JSONObject compoundExtractionsJson,
+    private Map<String, CompoundExtraction> parseCompoundExtractions(@Nullable final JSONObject compoundExtractionsJson,
             @NonNull final Map<String, List<Extraction>> candidates)
             throws JSONException {
+        if (compoundExtractionsJson == null) {
+            return Collections.emptyMap();
+        }
         final HashMap<String, CompoundExtraction> compoundExtractions = new HashMap<>();
         final Iterator<String> extractionsNameIterator = compoundExtractionsJson.keys();
         while (extractionsNameIterator.hasNext()) {

--- a/ginisdk/src/main/java/net/gini/android/internal/BundleHelper.java
+++ b/ginisdk/src/main/java/net/gini/android/internal/BundleHelper.java
@@ -1,0 +1,55 @@
+package net.gini.android.internal;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 13.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+public class BundleHelper {
+
+    public static <V extends Parcelable> Bundle mapToBundle(Map<String, V> map) {
+        final Bundle bundle = new Bundle();
+        for (final Map.Entry<String, V> entry : map.entrySet()) {
+            bundle.putParcelable(entry.getKey(), entry.getValue());
+        }
+        return bundle;
+    }
+
+    public static <V extends Parcelable> List<Bundle> mapListToBundleList(List<Map<String, V>> mapList) {
+        final List<Bundle> bundle = new ArrayList<>(mapList.size());
+        for (final Map<String, V> specificExtractionMap : mapList) {
+            bundle.add(mapToBundle(specificExtractionMap));
+        }
+        return bundle;
+    }
+
+    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle, ClassLoader classLoader){
+        bundle.setClassLoader(classLoader);
+        return bundleToMap(bundle);
+    }
+
+    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle){
+        final HashMap<String, V> map = new HashMap<>(bundle.keySet().size());
+        for (final String key : bundle.keySet()) {
+            map.put(key, bundle.<V>getParcelable(key));
+        }
+        return map;
+    }
+
+    public static <V extends Parcelable> List<Map<String, V>> bundleListToMapList(List<Bundle> bundleList, ClassLoader classLoader) {
+        final List<Map<String, V>> mapList = new ArrayList<>(bundleList.size());
+        for (final Bundle bundle : bundleList) {
+            mapList.add(BundleHelper.<V>bundleToMap(bundle, classLoader));
+        }
+        return mapList;
+    }
+
+}

--- a/ginisdk/src/main/java/net/gini/android/models/CompoundExtraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/CompoundExtraction.java
@@ -1,0 +1,77 @@
+package net.gini.android.models;
+
+import static net.gini.android.Utils.checkNotNull;
+import static net.gini.android.internal.BundleHelper.bundleListToMapList;
+import static net.gini.android.internal.BundleHelper.mapListToBundleList;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 13.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+public class CompoundExtraction implements Parcelable {
+
+    private final String mName;
+    private final List<Map<String, SpecificExtraction>> mSpecificExtractionMaps;
+
+    /**
+     * Value object for a compound extraction from the Gini API.
+     *
+     * @param name                      The compound extraction's name, e.g. "amountToPay".
+     * @param specificExtractionMaps    A list of specific extractions bundled into separate maps.
+     */
+    public CompoundExtraction(@NonNull final String name,
+            @NonNull final List<Map<String, SpecificExtraction>> specificExtractionMaps) {
+        mName = checkNotNull(name);
+        mSpecificExtractionMaps = checkNotNull(specificExtractionMaps);
+    }
+
+    @NonNull
+    public String getName() {
+        return mName;
+    }
+
+    @NonNull
+    public List<Map<String, SpecificExtraction>> getSpecificExtractionMaps() {
+        return mSpecificExtractionMaps;
+    }
+
+    protected CompoundExtraction(final Parcel in) {
+        mName = in.readString();
+        final List<Bundle> bundleList = new ArrayList<>();
+        in.readTypedList(bundleList, Bundle.CREATOR);
+        mSpecificExtractionMaps = bundleListToMapList(bundleList, getClass().getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(mName);
+        dest.writeTypedList(mapListToBundleList(mSpecificExtractionMaps));
+    }
+
+    public static final Parcelable.Creator<CompoundExtraction> CREATOR = new Parcelable.Creator<CompoundExtraction>() {
+        @Override
+        public CompoundExtraction createFromParcel(Parcel in) {
+            return new CompoundExtraction(in);
+        }
+
+        @Override
+        public CompoundExtraction[] newArray(int size) {
+            return new CompoundExtraction[size];
+        }
+    };
+}

--- a/ginisdk/src/main/java/net/gini/android/models/ExtractionsContainer.java
+++ b/ginisdk/src/main/java/net/gini/android/models/ExtractionsContainer.java
@@ -1,0 +1,80 @@
+package net.gini.android.models;
+
+import static net.gini.android.Utils.checkNotNull;
+import static net.gini.android.internal.BundleHelper.bundleToMap;
+import static net.gini.android.internal.BundleHelper.mapToBundle;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 13.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+
+/**
+ * Contains specific extractions (e.g. "amountToPay") and compound extractions (e.g. "lineItems").
+ * <p/>
+ * See the
+ * <a href="http://developer.gini.net/gini-api/html/document_extractions.html">Gini API documentation</a>
+ * for a list of the names of the specific extractions and compound specific extractions.
+ */
+public class ExtractionsContainer implements Parcelable {
+
+    private final Map<String, SpecificExtraction> mSpecificExtractions;
+    private final Map<String, CompoundExtraction> mCompoundExtractions;
+
+    /**
+     * Contains a document's extractions from the Gini API.
+     *
+     * @param specificExtractions
+     * @param compoundExtractions
+     */
+    public ExtractionsContainer(@NonNull final Map<String, SpecificExtraction> specificExtractions,
+            @NonNull final Map<String, CompoundExtraction> compoundExtractions) {
+        mSpecificExtractions = checkNotNull(specificExtractions);
+        mCompoundExtractions = checkNotNull(compoundExtractions);
+    }
+
+    @NonNull
+    public Map<String, SpecificExtraction> getSpecificExtractions() {
+        return mSpecificExtractions;
+    }
+
+    @NonNull
+    public Map<String, CompoundExtraction> getCompoundExtractions() {
+        return mCompoundExtractions;
+    }
+
+    protected ExtractionsContainer(Parcel in) {
+        mSpecificExtractions = bundleToMap(in.readBundle(getClass().getClassLoader()));
+        mCompoundExtractions = bundleToMap(in.readBundle(getClass().getClassLoader()));
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeBundle(mapToBundle(mSpecificExtractions));
+        dest.writeBundle(mapToBundle(mCompoundExtractions));
+    }
+
+    public static final Creator<ExtractionsContainer> CREATOR = new Creator<ExtractionsContainer>() {
+        @Override
+        public ExtractionsContainer createFromParcel(Parcel in) {
+            return new ExtractionsContainer(in);
+        }
+
+        @Override
+        public ExtractionsContainer[] newArray(int size) {
+            return new ExtractionsContainer[size];
+        }
+    };
+}

--- a/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
@@ -7,14 +7,12 @@ import android.os.Parcelable;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class SpecificExtraction extends Extraction {
 
     private final String mName;
     private final List<Extraction> mCandidates;
-    private final List<SpecificExtraction> mSpecificExtractions;
 
     /**
      * Value object for a specific extraction from the Gini API.
@@ -29,28 +27,10 @@ public class SpecificExtraction extends Extraction {
      */
     public SpecificExtraction(final String name, final String value, final String entity,
                               @Nullable final Box box, final List<Extraction> candidates) {
-        this(name, value, entity, box, candidates, Collections.<SpecificExtraction>emptyList());
-    }
-
-    /**
-     * Value object for a specific extraction from the Gini API.
-     *
-     * @param name                  The specific extraction's name, e.g. "amountToPay".
-     * @param value                 The extraction's value. Changing this value marks the extraction as dirty.
-     * @param entity                The extraction's entity.
-     * @param box                   Optional the box where the extraction is found. Only available on some
-     *                              extractions.
-     * @param candidates            A list containing other candidates for this specific extraction. Candidates
-     *                              are of the same entity as the found extraction.
-     * @param specificExtractions   A list of other specific extractions which are part of this one.
-     */
-    public SpecificExtraction(final String name, final String value, final String entity,
-            @Nullable final Box box, final List<Extraction> candidates, final List<SpecificExtraction> specificExtractions) {
         super(value, entity, box);
 
         mName = checkNotNull(name);
         mCandidates = checkNotNull(candidates);
-        mSpecificExtractions = specificExtractions;
     }
 
     /**
@@ -62,9 +42,6 @@ public class SpecificExtraction extends Extraction {
         final List<Extraction> candidates = new ArrayList<Extraction>();
         in.readTypedList(candidates, Extraction.CREATOR);
         mCandidates = candidates;
-        final List<SpecificExtraction> specificExtractions = new ArrayList<>();
-        in.readTypedList(specificExtractions, SpecificExtraction.CREATOR);
-        mSpecificExtractions = specificExtractions;
     }
 
     public String getName() {
@@ -73,10 +50,6 @@ public class SpecificExtraction extends Extraction {
 
     public List<Extraction> getCandidate() {
         return mCandidates;
-    }
-
-    public List<SpecificExtraction> getSpecificExtractions() {
-        return mSpecificExtractions;
     }
 
     @Override
@@ -89,7 +62,6 @@ public class SpecificExtraction extends Extraction {
         super.writeToParcel(dest, flags);
         dest.writeString(mName);
         dest.writeTypedList(mCandidates);
-        dest.writeTypedList(mSpecificExtractions);
     }
 
     public static final Parcelable.Creator<SpecificExtraction> CREATOR =


### PR DESCRIPTION
* Parses the updated json schema for line items.
* Deprecates the `DocumentTaskManager.getExtractions()` and introduces `getAllExtractions()` which returns an `ExtractionsContainer` object instead of a map to be able to return specific and compound extractions.