### PR TITLE
Updates TrustKit

### DIFF
--- a/ginisdk/build.gradle
+++ b/ginisdk/build.gradle
@@ -34,15 +34,17 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.volley:volley:1.1.0'
     api 'com.parse.bolts:bolts-android:1.1.3'
-    implementation 'com.datatheorem.android.trustkit:trustkit:1.0.2'
+    implementation 'com.datatheorem.android.trustkit:trustkit:1.1.3'
+    implementation 'androidx.core:core:1.3.0'
+    implementation 'androidx.preference:preference:1.1.1'
 
     // Mocks for testing.
     androidTestImplementation "org.mockito:mockito-core:1.10.19"
     androidTestImplementation "com.crittercism.dexmaker:dexmaker:1.4"
     androidTestImplementation "com.crittercism.dexmaker:dexmaker-dx:1.4"
     androidTestImplementation "com.crittercism.dexmaker:dexmaker-mockito:1.4"
-    androidTestImplementation "com.android.support.test:runner:1.0.1"
-    androidTestImplementation "com.android.support.test:rules:1.0.1"
+    androidTestImplementation "com.android.support.test:runner:1.0.2"
+    androidTestImplementation "com.android.support.test:rules:1.0.2"
 }
 
 apply from: file("repository.gradle")

--- a/ginisdk/gradle.properties
+++ b/ginisdk/gradle.properties
@@ -2,3 +2,4 @@ groupId=net.gini
 artifactId=gini-android-sdk
 baseVersion=2.4.1
 buildNumber=SNAPSHOT
+android.useAndroidX=true

--- a/ginisdk/src/androidTest/java/net/gini/android/authorization/crypto/GiniCryptoHelper.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/authorization/crypto/GiniCryptoHelper.java
@@ -1,11 +1,11 @@
 package net.gini.android.authorization.crypto;
 
-import android.support.annotation.NonNull;
-
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+
+import androidx.annotation.NonNull;
 
 /**
  * Created by Alpar Szotyori on 09.10.2018.

--- a/ginisdk/src/androidTest/res/xml/network_security_config.xml
+++ b/ginisdk/src/androidTest/res/xml/network_security_config.xml
@@ -7,9 +7,9 @@
         <domain includeSubdomains="false">api.gini.net</domain>
         <pin-set>
             <!-- old *.gini.net public key-->
-            <pin digest="SHA-256">yGLLyvZLo2NNXeBNKJwx1PlCtm+YEVU6h2hxVpRa4l4=</pin>
-            <!-- new *.gini.net public key, active from around mid August 2018 -->
             <pin digest="SHA-256">cNzbGowA+LNeQ681yMm8ulHxXiGojHE8qAjI+M7bIxU=</pin>
+            <!-- new *.gini.net public key, active from around June 2020 -->
+            <pin digest="SHA-256">zEVdOCzXU8euGVuMJYPr3DUU/d1CaKevtr0dW0XzZNo=</pin>
         </pin-set>
         <domain-config>
             <trustkit-config

--- a/ginisdk/src/main/java/net/gini/android/ApiCommunicator.java
+++ b/ginisdk/src/main/java/net/gini/android/ApiCommunicator.java
@@ -12,7 +12,7 @@ import static net.gini.android.Utils.mapToUrlEncodedString;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.RequestQueue;

--- a/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentMetadata.java
@@ -1,13 +1,13 @@
 package net.gini.android;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
-
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * Created by Alpar Szotyori on 25.10.2018.

--- a/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
+++ b/ginisdk/src/main/java/net/gini/android/DocumentTaskManager.java
@@ -7,8 +7,8 @@ import static net.gini.android.Utils.checkNotNull;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import net.gini.android.authorization.Session;
 import net.gini.android.authorization.SessionManager;

--- a/ginisdk/src/main/java/net/gini/android/GiniApiType.java
+++ b/ginisdk/src/main/java/net/gini/android/GiniApiType.java
@@ -2,7 +2,7 @@ package net.gini.android;
 
 import static net.gini.android.MediaTypes.*;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Created by Alpar Szotyori on 14.01.2019.

--- a/ginisdk/src/main/java/net/gini/android/MediaTypes.java
+++ b/ginisdk/src/main/java/net/gini/android/MediaTypes.java
@@ -1,8 +1,8 @@
 package net.gini.android;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class MediaTypes {
 

--- a/ginisdk/src/main/java/net/gini/android/RequestQueueBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/RequestQueueBuilder.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.support.annotation.XmlRes;
 
 import com.android.volley.Cache;
 import com.android.volley.Network;
@@ -24,6 +23,8 @@ import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
+
+import androidx.annotation.XmlRes;
 
 /**
  * <p>

--- a/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
@@ -4,8 +4,6 @@ import static net.gini.android.Utils.checkNotNull;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.support.annotation.NonNull;
-import android.support.annotation.XmlRes;
 
 import com.android.volley.Cache;
 import com.android.volley.DefaultRetryPolicy;
@@ -24,6 +22,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.XmlRes;
 
 public class SdkBuilder {
 

--- a/ginisdk/src/main/java/net/gini/android/authorization/AnonymousSessionManager.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/AnonymousSessionManager.java
@@ -4,7 +4,7 @@ package net.gini.android.authorization;
 import static net.gini.android.Utils.CHARSET_UTF8;
 import static net.gini.android.Utils.checkNotNull;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.android.volley.VolleyError;
 

--- a/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/EncryptedCredentialsStore.java
@@ -2,8 +2,8 @@ package net.gini.android.authorization;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import net.gini.android.authorization.crypto.GiniCrypto;
 import net.gini.android.authorization.crypto.GiniCryptoException;

--- a/ginisdk/src/main/java/net/gini/android/authorization/PubKeyManager.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/PubKeyManager.java
@@ -2,8 +2,6 @@ package net.gini.android.authorization;
 
 import android.content.Context;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.XmlRes;
 
 import com.datatheorem.android.trustkit.TrustKit;
 import com.datatheorem.android.trustkit.config.DomainPinningPolicy;
@@ -21,6 +19,9 @@ import java.util.Set;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.XmlRes;
 
 
 public final class PubKeyManager implements X509TrustManager {

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCrypto.java
@@ -3,8 +3,8 @@ package net.gini.android.authorization.crypto;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import android.util.Base64;
 
 import java.io.IOException;

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoAndroidMOrGreater.java
@@ -3,8 +3,8 @@ package net.gini.android.authorization.crypto;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;

--- a/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -3,7 +3,7 @@ package net.gini.android.authorization.crypto;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.security.KeyPairGeneratorSpec;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Base64;
 

--- a/ginisdk/src/main/java/net/gini/android/authorization/requests/BearerJsonObjectRequest.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/requests/BearerJsonObjectRequest.java
@@ -1,7 +1,7 @@
 package net.gini.android.authorization.requests;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;

--- a/ginisdk/src/main/java/net/gini/android/authorization/requests/TokenRequest.java
+++ b/ginisdk/src/main/java/net/gini/android/authorization/requests/TokenRequest.java
@@ -3,7 +3,7 @@ package net.gini.android.authorization.requests;
 
 import static net.gini.android.Utils.mapToUrlEncodedString;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Base64;
 
 import com.android.volley.AuthFailureError;

--- a/ginisdk/src/main/java/net/gini/android/models/CompoundExtraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/CompoundExtraction.java
@@ -7,7 +7,7 @@ import static net.gini.android.internal.BundleHelper.mapListToBundleList;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ginisdk/src/main/java/net/gini/android/models/Document.java
+++ b/ginisdk/src/main/java/net/gini/android/models/Document.java
@@ -6,7 +6,7 @@ import static net.gini.android.Utils.checkNotNull;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.json.JSONArray;

--- a/ginisdk/src/main/java/net/gini/android/models/Extraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/Extraction.java
@@ -4,7 +4,7 @@ import static net.gini.android.Utils.checkNotNull;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class Extraction implements Parcelable {
     private String mValue;

--- a/ginisdk/src/main/java/net/gini/android/models/ExtractionsContainer.java
+++ b/ginisdk/src/main/java/net/gini/android/models/ExtractionsContainer.java
@@ -6,7 +6,7 @@ import static net.gini.android.internal.BundleHelper.mapToBundle;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.Map;
 

--- a/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
+++ b/ginisdk/src/main/java/net/gini/android/models/SpecificExtraction.java
@@ -4,7 +4,7 @@ import static net.gini.android.Utils.checkNotNull;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Updated TrustKit to 1.1.3. 

This resulted in not having any dependencies using the support library anymore so I also had to add AndroidX to keep using the nullability annotations. This has the added benefit, that we are now fully free of the deprecated support library in production code.

Tests still use the testing support libraries due to some bug in the AndroidX testing libraries which prevents the test runner to see the tests. 