### PR TITLE
Release version 2.10.0

### DIFF
--- a/ginisdk/gradle.properties
+++ b/ginisdk/gradle.properties
@@ -1,6 +1,6 @@
 groupId=net.gini
 artifactId=gini-android-sdk
-version=2.9.2
+version=2.10.0
 buildNumber=SNAPSHOT
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ginisdk/src/androidTest/java/net/gini/android/RequestQueueBuilderTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/RequestQueueBuilderTest.java
@@ -14,6 +14,12 @@ import com.android.volley.toolbox.NoCache;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 @SmallTest
 @RunWith(AndroidJUnit4.class)
 public class RequestQueueBuilderTest {
@@ -35,6 +41,35 @@ public class RequestQueueBuilderTest {
                 .build();
 
         assertSame(cache, requestQueue.getCache());
+    }
+
+    @Test
+    public void allowSettingCustomTrustManager() {
+        RequestQueueBuilder requestQueueBuilder = new RequestQueueBuilder(getApplicationContext());
+
+        final TrustManager trustManager = new X509TrustManager() {
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+
+        RequestQueue requestQueue = requestQueueBuilder
+                .setTrustManager(trustManager)
+                .build();
+
+        assertNotNull(requestQueue);
     }
 
 }

--- a/ginisdk/src/androidTest/java/net/gini/android/SdkBuilderTest.java
+++ b/ginisdk/src/androidTest/java/net/gini/android/SdkBuilderTest.java
@@ -19,6 +19,12 @@ import net.gini.android.authorization.SessionManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 import bolts.Task;
 
 @SmallTest
@@ -104,6 +110,34 @@ public class SdkBuilderTest {
         Gini sdkInstance = builder.build();
 
         assertSame(sdkInstance.getDocumentTaskManager().mApiCommunicator.mRequestQueue.getCache(), nullCache);
+    }
+
+    @Test
+    public void allowsSettingCustomTrustManager() {
+        SdkBuilder builder = new SdkBuilder(getApplicationContext(), "clientId", "clientSecret", "@example.com");
+        final TrustManager trustManager = new X509TrustManager() {
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+
+        Gini sdkInstance = builder
+                .setTrustManager(trustManager)
+                .build();
+
+        assertNotNull(sdkInstance);
     }
 
     private static final class NullCache implements Cache {

--- a/ginisdk/src/doc/source/guides/getting-started.rst
+++ b/ginisdk/src/doc/source/guides/getting-started.rst
@@ -29,7 +29,7 @@ repository to your build script. You also need to add jcenter and the sonatype s
     }
 
     dependencies {
-        compile ('net.gini:gini-android-sdk:2.9.2@aar'){
+        compile ('net.gini:gini-android-sdk:2.10.0@aar'){
             transitive = true
         }
         ...

--- a/ginisdk/src/doc/source/guides/getting-started.rst
+++ b/ginisdk/src/doc/source/guides/getting-started.rst
@@ -108,16 +108,22 @@ Since version 1.5.0 public key pinning is provided using the `Android Network Se
 <https://github.com/datatheorem/TrustKit-Android>`_. The previous configuration through the
 `SdkBuilder` was removed.
 
-To use public key pinning you need to create an `Android network security configuration
-<https://developer.android.com/training/articles/security-config.html>`_ xml file. This
-configuration is supported natively on Android Nougat (API Level 24) and newer. For versions between
-API Level 17 and 23 the Gini SDK relies on `TrustKit
-<https://github.com/datatheorem/TrustKit-Android>`_. On API Levels 15 and 16 our own pinning
-implementation is used.
+Since version 2.10.0 it is also possible to use a custom `TrustManager
+<https://developer.android.com/reference/javax/net/ssl/TrustManager>`_ to pin certificates.
+
+To use public key pinning you can either create an `Android network security configuration
+<https://developer.android.com/training/articles/security-config.html>`_ xml file or set a custom `TrustManager
+<https://developer.android.com/reference/javax/net/ssl/TrustManager>`_ implementation. 
+
+The network security configuration is supported
+natively on Android Nougat (API Level 24) and newer. For versions between API Level 19 and 23 the Gini SDK relies on
+`TrustKit <https://github.com/datatheorem/TrustKit-Android>`_.
+
+The custom ``TrustManager`` is supported on all Android versions.
 
 We recommend reading the `Android Network Security Configuration
 <https://developer.android.com/training/articles/security-config.html>`_ guide and the `TrustKit
-limitations for API Levels 17 to 23 <https://github.com/datatheorem/TrustKit-Android#limitations>`_.
+limitations for API Levels 19 to 23 <https://github.com/datatheorem/TrustKit-Android#limitations>`_.
 
 Configure Pinning
 -----------------
@@ -186,8 +192,8 @@ the ``<application>`` tag to point to the xml:
         ...
     </manifest>
 
-Enable Pinning
---------------
+Enable Pinning with a Network Security Configuration
+----------------------------------------------------
 
 For the Gini SDK to know about the xml you need to set the xml resource id using the
 ``SdkBuilder#setNetworkSecurityConfigResId()`` method:
@@ -197,6 +203,23 @@ For the Gini SDK to know about the xml you need to set the xml resource id using
     Gini gini = new SdkBuilder(getContext(), "gini-client-id", "GiniClientSecret", "example.com")
             .setNetworkSecurityConfigResId(R.xml.network_security_config)
             .build();
+
+
+Enable Pinning with a custom TrustManager implementation
+--------------------------------------------------------
+
+You can also take full control over which certificates to trust by passing your own ``TrustManager`` implementation
+to the ``SdkBuilder#setTrustManager()`` method:
+
+.. code-block:: java
+
+    Gini gini = new SdkBuilder(getContext(), "gini-client-id", "GiniClientSecret", "example.com")
+            .setTrustManager(yourTrustManager)
+            .build();
+
+.. warning::
+
+    Setting a custom ``TrustManager`` will override the network security configuration.
 
 Extract Hash From gini.net
 --------------------------

--- a/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
+++ b/ginisdk/src/main/java/net/gini/android/SdkBuilder.java
@@ -26,6 +26,8 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.XmlRes;
 
+import javax.net.ssl.TrustManager;
+
 public class SdkBuilder {
 
     private final Context mContext;
@@ -52,6 +54,7 @@ public class SdkBuilder {
     private RetryPolicyFactory mRetryPolicyFactory;
     private Cache mCache;
     private GiniApiType mGiniApiType;
+    private TrustManager mTrustManager;
 
     /**
      * Constructor to initialize a new builder instance where anonymous Gini users are used. <b>This requires access to
@@ -204,6 +207,21 @@ public class SdkBuilder {
     }
 
     /**
+     * Set a custom {@link TrustManager} implementation to have full control over which certificates to trust.
+     * <p>
+     * Please be aware that if you set a custom TrustManager implementation here than it will override any
+     * <a href="https://developer.android.com/training/articles/security-config">network security configuration</a>
+     * you may have set.
+     *
+     * @param trustManager A {@link TrustManager} implementation.
+     * @return The builder instance to enable chaining.
+     */
+    public SdkBuilder setTrustManager(@NonNull final TrustManager trustManager) {
+        mTrustManager = trustManager;
+        return this;
+    }
+
+    /**
      * Builds the Gini instance with the configuration settings of the builder instance.
      *
      * @return The fully configured Gini instance.
@@ -228,6 +246,8 @@ public class SdkBuilder {
             }
             if (mNetworkSecurityConfigResId != 0) {
                 requestQueueBuilder.setNetworkSecurityConfigResId(mNetworkSecurityConfigResId);
+            } else if (mTrustManager != null) {
+                requestQueueBuilder.setTrustManager(mTrustManager);
             }
             mRequestQueue = requestQueueBuilder.build();
         }


### PR DESCRIPTION
* Allows setting a custom [TrustManager](https://developer.android.com/reference/javax/net/ssl/TrustManager) implementation to have full control over which remote certificates to trust.